### PR TITLE
Configura esqueleto Scala inicial

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [OrganizeImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = 3.7.8
+maxColumn = 100
+align = most

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Entystal
+
+Esqueleto de proyecto Scala para aplicaciones de trazabilidad, balance y certificación ética.
+
+## Estructura
+
+Ver carpeta `core/` para el módulo principal.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,34 @@
+ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / organization := "io.entystal"
+ThisBuild / version      := "0.1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .aggregate(core)
+  .settings(
+    name := "entystal-root"
+  )
+
+lazy val core = (project in file("core"))
+  .settings(
+    name := "entystal-core",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio"          % "2.0.15",
+      "dev.zio" %% "zio-logging"  % "2.1.13",
+      "dev.zio" %% "zio-json"     % "0.4.3",
+      "org.tpolecat" %% "doobie-core"  % "1.0.0-RC4",
+      "org.tpolecat" %% "doobie-postgres" % "1.0.0-RC4",
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "dev.zio" %% "zio-test"     % "2.0.15" % Test,
+      "dev.zio" %% "zio-test-sbt" % "2.0.15" % Test,
+      "com.github.scopt" %% "scopt" % "4.1.0"
+    ),
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      "-encoding", "utf8",
+      "-Xfatal-warnings"
+    ),
+    Test / fork := true,
+    Test / parallelExecution := false
+  )

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,3 @@
+# Entystal Core
+
+Módulo principal con modelos financieros y lógica de contabilidad.

--- a/core/src/main/scala/entystal/EntystalModule.scala
+++ b/core/src/main/scala/entystal/EntystalModule.scala
@@ -1,0 +1,13 @@
+package entystal
+
+import entystal.ledger.Ledger
+import entystal.model.{Asset, Balance, Liability}
+
+object EntystalModule {
+  def empty: Ledger = Ledger(Balance(Nil, Nil))
+
+  def demoLedger: Ledger =
+    empty
+      .addAsset(Asset("cash", 1000))
+      .addLiability(Liability("debt", 200))
+}

--- a/core/src/main/scala/entystal/ledger/Ledger.scala
+++ b/core/src/main/scala/entystal/ledger/Ledger.scala
@@ -1,0 +1,11 @@
+package entystal.ledger
+
+import entystal.model.{Asset, Balance, Liability}
+
+final case class Ledger(balance: Balance) {
+  def addAsset(asset: Asset): Ledger =
+    copy(balance = balance.copy(assets = asset :: balance.assets))
+
+  def addLiability(liability: Liability): Ledger =
+    copy(balance = balance.copy(liabilities = liability :: balance.liabilities))
+}

--- a/core/src/main/scala/entystal/model/Asset.scala
+++ b/core/src/main/scala/entystal/model/Asset.scala
@@ -1,0 +1,3 @@
+package entystal.model
+
+final case class Asset(id: String, value: BigDecimal)

--- a/core/src/main/scala/entystal/model/Balance.scala
+++ b/core/src/main/scala/entystal/model/Balance.scala
@@ -1,0 +1,6 @@
+package entystal.model
+
+final case class Balance(assets: List[Asset], liabilities: List[Liability]) {
+  def netWorth: BigDecimal =
+    assets.map(_.value).sum - liabilities.map(_.amount).sum
+}

--- a/core/src/main/scala/entystal/model/Investment.scala
+++ b/core/src/main/scala/entystal/model/Investment.scala
@@ -1,0 +1,3 @@
+package entystal.model
+
+final case class Investment(id: String, quantity: BigDecimal)

--- a/core/src/main/scala/entystal/model/Liability.scala
+++ b/core/src/main/scala/entystal/model/Liability.scala
@@ -1,0 +1,3 @@
+package entystal.model
+
+final case class Liability(id: String, amount: BigDecimal)

--- a/core/src/test/scala/entystal/EntystalModuleSpec.scala
+++ b/core/src/test/scala/entystal/EntystalModuleSpec.scala
@@ -1,0 +1,11 @@
+package entystal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EntystalModuleSpec extends AnyFlatSpec with Matchers {
+  "EntystalModule" should "provide a demo ledger" in {
+    val ledger = EntystalModule.demoLedger
+    ledger.balance.netWorth shouldBe 800
+  }
+}

--- a/core/src/test/scala/entystal/ledger/LedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/LedgerSpec.scala
@@ -1,0 +1,15 @@
+package entystal.ledger
+
+import entystal.model.{Asset, Balance, Liability}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LedgerSpec extends AnyFlatSpec with Matchers {
+  "A Ledger" should "update balance" in {
+    val ledger = Ledger(Balance(Nil, Nil))
+      .addAsset(Asset("cash", 100))
+      .addLiability(Liability("loan", 50))
+
+    ledger.balance.netWorth shouldBe 50
+  }
+}

--- a/core/src/test/scala/entystal/model/AssetSpec.scala
+++ b/core/src/test/scala/entystal/model/AssetSpec.scala
@@ -1,0 +1,11 @@
+package entystal.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AssetSpec extends AnyFlatSpec with Matchers {
+  "An Asset" should "hold its value" in {
+    val asset = Asset("a1", 100)
+    asset.value shouldBe 100
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
## Resumen
- añade `build.sbt` con dependencias y opciones
- configura `plugins.sbt`
- crea estructura de carpetas y modelos básicos
- agrega pruebas unitarias mínimas
- incluye configuraciones de scalafmt y scalafix

## Testing
- `sbt scalafmtAll` *(falló: comando no encontrado)*
- `sbt test` *(falló: comando no encontrado)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685c243026c0832b9dd6df71b9142a4a