### PR TITLE
Configura ledger funcional y pruebas ZIO

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [OrganizeImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = 3.7.8
+maxColumn = 100
+align = most

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Entystal
+
+Esqueleto de proyecto Scala para aplicaciones de trazabilidad, balance y certificación ética.
+
+## Estructura
+
+Ver carpeta `core/` para el módulo principal.
+
+## Uso
+
+Requiere [sbt](https://www.scala-sbt.org/) instalado.
+
+```bash
+sbt scalafmtAll   # Formateo de código
+sbt test          # Ejecutar pruebas
+```

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,34 @@
+ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / organization := "io.entystal"
+ThisBuild / version      := "0.1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .aggregate(core)
+  .settings(
+    name := "entystal-root"
+  )
+
+lazy val core = (project in file("core"))
+  .settings(
+    name := "entystal-core",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio"          % "2.0.15",
+      "dev.zio" %% "zio-logging"  % "2.1.13",
+      "dev.zio" %% "zio-json"     % "0.4.3",
+      "org.tpolecat" %% "doobie-core"  % "1.0.0-RC4",
+      "org.tpolecat" %% "doobie-postgres" % "1.0.0-RC4",
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "dev.zio" %% "zio-test"     % "2.0.15" % Test,
+      "dev.zio" %% "zio-test-sbt" % "2.0.15" % Test,
+      "com.github.scopt" %% "scopt" % "4.1.0"
+    ),
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      "-encoding", "utf8",
+      "-Xfatal-warnings"
+    ),
+    Test / fork := true,
+    Test / parallelExecution := false
+  )

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,3 @@
+# Entystal Core
+
+Módulo principal con modelos financieros y lógica de contabilidad.

--- a/core/src/main/scala/entystal/EntystalModule.scala
+++ b/core/src/main/scala/entystal/EntystalModule.scala
@@ -1,0 +1,9 @@
+package entystal
+
+import entystal.ledger.{InMemoryLedger, Ledger}
+import zio.ULayer
+
+/** Capa principal que expone el Ledger en memoria */
+object EntystalModule {
+  val layer: ULayer[Ledger] = InMemoryLedger.live
+}

--- a/core/src/main/scala/entystal/ledger/Ledger.scala
+++ b/core/src/main/scala/entystal/ledger/Ledger.scala
@@ -1,0 +1,49 @@
+package entystal.ledger
+
+import entystal.model.{Asset, Investment, Liability}
+import zio.{Ref, UIO, ULayer, ZLayer}
+
+/** Registro funcional en memoria de eventos contables */
+trait Ledger {
+  def recordAsset(asset: Asset): UIO[Unit]
+  def recordLiability(liability: Liability): UIO[Unit]
+  def recordInvestment(investment: Investment): UIO[Unit]
+  def getHistory: UIO[List[LedgerEntry]]
+}
+
+sealed trait LedgerEntry {
+  def id: String
+  def timestamp: Long
+}
+
+final case class AssetEntry(asset: Asset) extends LedgerEntry {
+  val id: String = asset.id
+  val timestamp: Long = asset.timestamp
+}
+
+final case class LiabilityEntry(liability: Liability) extends LedgerEntry {
+  val id: String = liability.id
+  val timestamp: Long = liability.timestamp
+}
+
+final case class InvestmentEntry(investment: Investment) extends LedgerEntry {
+  val id: String = investment.id
+  val timestamp: Long = investment.timestamp
+}
+
+object InMemoryLedger {
+  def live: ULayer[Ledger] =
+    ZLayer {
+      for {
+        ref <- Ref.make(List.empty[LedgerEntry])
+      } yield new Ledger {
+        override def recordAsset(asset: Asset): UIO[Unit] =
+          ref.update(_ :+ AssetEntry(asset))
+        override def recordLiability(liability: Liability): UIO[Unit] =
+          ref.update(_ :+ LiabilityEntry(liability))
+        override def recordInvestment(investment: Investment): UIO[Unit] =
+          ref.update(_ :+ InvestmentEntry(investment))
+        override def getHistory: UIO[List[LedgerEntry]] = ref.get
+      }
+    }
+}

--- a/core/src/main/scala/entystal/model/Asset.scala
+++ b/core/src/main/scala/entystal/model/Asset.scala
@@ -1,0 +1,14 @@
+package entystal.model
+
+trait Asset {
+  def id: String
+  def timestamp: Long
+  def value: BigDecimal
+}
+
+final case class DataAsset(
+    id: String,
+    data: String,
+    timestamp: Long,
+    value: BigDecimal
+) extends Asset

--- a/core/src/main/scala/entystal/model/Balance.scala
+++ b/core/src/main/scala/entystal/model/Balance.scala
@@ -1,0 +1,6 @@
+package entystal.model
+
+final case class Balance(assets: List[Asset], liabilities: List[Liability]) {
+  def netWorth: BigDecimal =
+    assets.map(_.value).sum - liabilities.map(_.amount).sum
+}

--- a/core/src/main/scala/entystal/model/Investment.scala
+++ b/core/src/main/scala/entystal/model/Investment.scala
@@ -1,0 +1,13 @@
+package entystal.model
+
+trait Investment {
+  def id: String
+  def timestamp: Long
+  def quantity: BigDecimal
+}
+
+final case class BasicInvestment(
+    id: String,
+    quantity: BigDecimal,
+    timestamp: Long
+) extends Investment

--- a/core/src/main/scala/entystal/model/Liability.scala
+++ b/core/src/main/scala/entystal/model/Liability.scala
@@ -1,0 +1,13 @@
+package entystal.model
+
+trait Liability {
+  def id: String
+  def timestamp: Long
+  def amount: BigDecimal
+}
+
+final case class BasicLiability(
+    id: String,
+    amount: BigDecimal,
+    timestamp: Long
+) extends Liability

--- a/core/src/test/scala/entystal/EntystalModuleSpec.scala
+++ b/core/src/test/scala/entystal/EntystalModuleSpec.scala
@@ -1,0 +1,15 @@
+package entystal
+
+import zio.test.{ZIOSpecDefault, assertTrue, Spec, TestEnvironment}
+
+object EntystalModuleSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("EntystalModuleSpec")(
+      test("la capa proporciona un ledger vac\u00edo") {
+        for {
+          ledger   <- EntystalModule.layer.build.map(_.get)
+          history  <- ledger.getHistory
+        } yield assertTrue(history.isEmpty)
+      }
+    )
+}

--- a/core/src/test/scala/entystal/ledger/LedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/LedgerSpec.scala
@@ -1,0 +1,18 @@
+package entystal.ledger
+
+import entystal.model.DataAsset
+import zio.test.{ZIOSpecDefault, assertTrue, Spec, TestEnvironment}
+
+object LedgerSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("LedgerSpec")(
+      test("Registra y recupera activos correctamente") {
+        val asset = DataAsset("id-1", "Datos relevantes", 1L, BigDecimal(42))
+        for {
+          ledger  <- InMemoryLedger.live.build.map(_.get)
+          _       <- ledger.recordAsset(asset)
+          history <- ledger.getHistory
+        } yield assertTrue(history.contains(AssetEntry(asset)))
+      }
+    )
+}

--- a/core/src/test/scala/entystal/model/AssetSpec.scala
+++ b/core/src/test/scala/entystal/model/AssetSpec.scala
@@ -1,0 +1,11 @@
+package entystal.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AssetSpec extends AnyFlatSpec with Matchers {
+  "Un DataAsset" should "mantener su valor" in {
+    val asset = DataAsset("a1", "info", 1L, BigDecimal(100))
+    asset.value shouldBe BigDecimal(100)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
## Resumen
- implementa Ledger funcional con capa `InMemoryLedger`
- expone `layer` en `EntystalModule`
- amplía modelos para incluir timestamp
- actualiza pruebas a ZIO Test y ScalaTest
- corrige valores de BigDecimal en los tests
- amplía README con instrucciones de uso

## Testing
- `sbt scalafmtAll` *(falló: command not found)*
- `sbt test` *(falló: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685c243026c0832b9dd6df71b9142a4a