### PR TITLE
Configura SQL y test de SqlLedger

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [OrganizeImports]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = 3.7.8
+maxColumn = 100
+align = most

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # Entystal
+
+Esqueleto de proyecto Scala para aplicaciones de trazabilidad, balance y certificación ética.
+
+## Estructura
+
+Revisa la carpeta `core/` para el módulo principal.
+
+## Uso
+
+Requiere [sbt](https://www.scala-sbt.org/) instalado.
+
+```bash
+sbt scalafmtAll   # Formateo de código
+sbt test          # Ejecutar pruebas
+```
+
+Ejemplo de registro por CLI:
+
+```bash
+sbt "core/run --mode asset --assetId id-101 --assetDesc 'Datos relevantes CLI'"
+```
+
+Antes, configura PostgreSQL con `core/sql/entystal_schema.sql` si vas a usar `SqlLedger`.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,34 @@
+ThisBuild / scalaVersion := "2.13.12"
+ThisBuild / organization := "io.entystal"
+ThisBuild / version      := "0.1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .aggregate(core)
+  .settings(
+    name := "entystal-root"
+  )
+
+lazy val core = (project in file("core"))
+  .settings(
+    name := "entystal-core",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio"          % "2.0.15",
+      "dev.zio" %% "zio-logging"  % "2.1.13",
+      "dev.zio" %% "zio-json"     % "0.4.3",
+      "org.tpolecat" %% "doobie-core"  % "1.0.0-RC4",
+      "org.tpolecat" %% "doobie-postgres" % "1.0.0-RC4",
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "dev.zio" %% "zio-test"     % "2.0.15" % Test,
+      "dev.zio" %% "zio-test-sbt" % "2.0.15" % Test,
+      "com.github.scopt" %% "scopt" % "4.1.0"
+    ),
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      "-encoding", "utf8",
+      "-Xfatal-warnings"
+    ),
+    Test / fork := true,
+    Test / parallelExecution := false
+  )

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,15 @@
+# entystal-core
+
+Sistema funcional en Scala para trazabilidad ética, balance y registro auditable de recursos en proyectos colaborativos.
+Incluye modelos de activos, pasivos e inversiones, ledger funcional concurrente y persistencia opcional en PostgreSQL.
+
+## Uso rápido
+1. Clona el repo y lanza `sbt compile`.
+2. Configura PostgreSQL y ejecuta el script `core/sql/entystal_schema.sql`.
+3. Prueba la CLI:
+   `sbt "core/run --mode asset --assetId id-101 --assetDesc 'Datos relevantes CLI'"`
+4. Ejecuta los tests:
+   `sbt core/test`
+
+## Extensiones
+- API REST, control de acceso, exportación JSON, métricas Prometheus.

--- a/core/sql/entystal_schema.sql
+++ b/core/sql/entystal_schema.sql
@@ -1,0 +1,29 @@
+-- Activos
+CREATE TABLE IF NOT EXISTS asset (
+  id TEXT PRIMARY KEY,
+  description TEXT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  data_points INTEGER,
+  lines_of_code INTEGER,
+  score DOUBLE PRECISION
+);
+
+-- Pasivos
+CREATE TABLE IF NOT EXISTS liability (
+  id TEXT PRIMARY KEY,
+  description TEXT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  severity INTEGER,
+  cost_estimate NUMERIC,
+  compliance_issue TEXT
+);
+
+-- Inversiones
+CREATE TABLE IF NOT EXISTS investment (
+  id TEXT PRIMARY KEY,
+  description TEXT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  amount NUMERIC,
+  participants INTEGER,
+  hours INTEGER
+);

--- a/core/src/main/scala/entystal/EntystalModule.scala
+++ b/core/src/main/scala/entystal/EntystalModule.scala
@@ -1,0 +1,9 @@
+package entystal
+
+import entystal.ledger.{InMemoryLedger, Ledger}
+import zio.ULayer
+
+/** Capa principal que expone el Ledger en memoria */
+object EntystalModule {
+  val layer: ULayer[Ledger] = InMemoryLedger.live
+}

--- a/core/src/main/scala/entystal/cli/Main.scala
+++ b/core/src/main/scala/entystal/cli/Main.scala
@@ -1,0 +1,43 @@
+package entystal.cli
+
+import entystal._
+import entystal.ledger._
+import entystal.model._
+import zio._
+import scopt.OParser
+
+case class Config(
+  assetId: Option[String] = None,
+  assetDesc: Option[String] = None,
+  mode: String = "asset"
+)
+
+object Main extends ZIOAppDefault {
+  val builder = OParser.builder[Config]
+  val parser = {
+    import builder._
+    OParser.sequence(
+      programName("entystal-cli"),
+      head("entystal", "0.1"),
+      opt[String]("assetId").action((x, c) => c.copy(assetId = Some(x))),
+      opt[String]("assetDesc").action((x, c) => c.copy(assetDesc = Some(x))),
+      opt[String]("mode").action((x, c) => c.copy(mode = x))
+    )
+  }
+
+  def run = {
+    val argsArray = Option(System.getenv("ARGS")).fold(Array.empty[String])(_.split(" "))
+    OParser.parse(parser, argsArray, Config()) match {
+      case Some(cfg) if cfg.mode == "asset" && cfg.assetId.nonEmpty && cfg.assetDesc.nonEmpty =>
+        for {
+          ledger <- EntystalModule.layer.build.map(_.get)
+          ts     = System.currentTimeMillis
+          asset  = DataAsset(cfg.assetId.get, cfg.assetDesc.get, ts, BigDecimal(1))
+          _      <- ledger.recordAsset(asset)
+          _      <- Console.printLine(s"Registrado activo: $asset")
+        } yield ()
+      case _ =>
+        Console.printLine("Par\u00e1metros insuficientes o incorrectos.")
+    }
+  }
+}

--- a/core/src/main/scala/entystal/ledger/Ledger.scala
+++ b/core/src/main/scala/entystal/ledger/Ledger.scala
@@ -1,0 +1,49 @@
+package entystal.ledger
+
+import entystal.model.{Asset, Investment, Liability}
+import zio.{Ref, UIO, ULayer, ZLayer}
+
+/** Registro funcional en memoria de eventos contables */
+trait Ledger {
+  def recordAsset(asset: Asset): UIO[Unit]
+  def recordLiability(liability: Liability): UIO[Unit]
+  def recordInvestment(investment: Investment): UIO[Unit]
+  def getHistory: UIO[List[LedgerEntry]]
+}
+
+sealed trait LedgerEntry {
+  def id: String
+  def timestamp: Long
+}
+
+final case class AssetEntry(asset: Asset) extends LedgerEntry {
+  val id: String = asset.id
+  val timestamp: Long = asset.timestamp
+}
+
+final case class LiabilityEntry(liability: Liability) extends LedgerEntry {
+  val id: String = liability.id
+  val timestamp: Long = liability.timestamp
+}
+
+final case class InvestmentEntry(investment: Investment) extends LedgerEntry {
+  val id: String = investment.id
+  val timestamp: Long = investment.timestamp
+}
+
+object InMemoryLedger {
+  def live: ULayer[Ledger] =
+    ZLayer {
+      for {
+        ref <- Ref.make(List.empty[LedgerEntry])
+      } yield new Ledger {
+        override def recordAsset(asset: Asset): UIO[Unit] =
+          ref.update(_ :+ AssetEntry(asset))
+        override def recordLiability(liability: Liability): UIO[Unit] =
+          ref.update(_ :+ LiabilityEntry(liability))
+        override def recordInvestment(investment: Investment): UIO[Unit] =
+          ref.update(_ :+ InvestmentEntry(investment))
+        override def getHistory: UIO[List[LedgerEntry]] = ref.get
+      }
+    }
+}

--- a/core/src/main/scala/entystal/ledger/SqlLedger.scala
+++ b/core/src/main/scala/entystal/ledger/SqlLedger.scala
@@ -1,0 +1,28 @@
+package entystal.ledger
+
+import entystal.model._
+import zio._
+import doobie._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+
+/** Ledger persistente sobre PostgreSQL usando Doobie */
+class SqlLedger(xa: Transactor[Task]) extends Ledger {
+  override def recordAsset(asset: Asset): UIO[Unit] =
+    sql"INSERT INTO asset (id, description, timestamp) VALUES (${asset.id}, ${asset.toString}, ${asset.timestamp})".update.run.transact(xa).orDie.unit
+
+  // Métodos para los demás registros
+  override def recordLiability(liability: Liability): UIO[Unit] =
+    ZIO.unit // TODO implementar
+
+  override def recordInvestment(investment: Investment): UIO[Unit] =
+    ZIO.unit // TODO implementar
+
+  override def getHistory: UIO[List[LedgerEntry]] =
+    ZIO.succeed(List.empty) // TODO implementar
+}
+
+object SqlLedger {
+  def layer(xa: Transactor[Task]): ULayer[Ledger] =
+    ZLayer.succeed(new SqlLedger(xa))
+}

--- a/core/src/main/scala/entystal/model/Asset.scala
+++ b/core/src/main/scala/entystal/model/Asset.scala
@@ -1,0 +1,28 @@
+package entystal.model
+
+trait Asset {
+  def id: String
+  def timestamp: Long
+  def value: BigDecimal
+}
+
+final case class DataAsset(
+    id: String,
+    data: String,
+    timestamp: Long,
+    value: BigDecimal
+) extends Asset
+
+final case class CodeAsset(
+    id: String,
+    repo: String,
+    timestamp: Long,
+    value: BigDecimal
+) extends Asset
+
+final case class ReputationAsset(
+    id: String,
+    score: Int,
+    timestamp: Long,
+    value: BigDecimal
+) extends Asset

--- a/core/src/main/scala/entystal/model/Balance.scala
+++ b/core/src/main/scala/entystal/model/Balance.scala
@@ -1,0 +1,6 @@
+package entystal.model
+
+final case class Balance(assets: List[Asset], liabilities: List[Liability]) {
+  def netWorth: BigDecimal =
+    assets.map(_.value).sum - liabilities.map(_.amount).sum
+}

--- a/core/src/main/scala/entystal/model/Investment.scala
+++ b/core/src/main/scala/entystal/model/Investment.scala
@@ -1,0 +1,31 @@
+package entystal.model
+
+trait Investment {
+  def id: String
+  def timestamp: Long
+  def quantity: BigDecimal
+}
+
+final case class BasicInvestment(
+    id: String,
+    quantity: BigDecimal,
+    timestamp: Long
+) extends Investment
+
+final case class EconomicInvestment(
+    id: String,
+    quantity: BigDecimal,
+    timestamp: Long
+) extends Investment
+
+final case class HumanInvestment(
+    id: String,
+    quantity: BigDecimal,
+    timestamp: Long
+) extends Investment
+
+final case class OperationalInvestment(
+    id: String,
+    quantity: BigDecimal,
+    timestamp: Long
+) extends Investment

--- a/core/src/main/scala/entystal/model/JsonCodecs.scala
+++ b/core/src/main/scala/entystal/model/JsonCodecs.scala
@@ -1,0 +1,18 @@
+package entystal.model
+
+import zio.json._
+
+/** Codificadores JSON para los modelos */
+object JsonCodecs {
+  implicit val dataAssetCodec: JsonCodec[DataAsset] = DeriveJsonCodec.gen[DataAsset]
+  implicit val codeAssetCodec: JsonCodec[CodeAsset] = DeriveJsonCodec.gen[CodeAsset]
+  implicit val reputationAssetCodec: JsonCodec[ReputationAsset] = DeriveJsonCodec.gen[ReputationAsset]
+
+  implicit val ethicalLiabilityCodec: JsonCodec[EthicalLiability] = DeriveJsonCodec.gen[EthicalLiability]
+  implicit val strategicLiabilityCodec: JsonCodec[StrategicLiability] = DeriveJsonCodec.gen[StrategicLiability]
+  implicit val legalLiabilityCodec: JsonCodec[LegalLiability] = DeriveJsonCodec.gen[LegalLiability]
+
+  implicit val economicInvestmentCodec: JsonCodec[EconomicInvestment] = DeriveJsonCodec.gen[EconomicInvestment]
+  implicit val humanInvestmentCodec: JsonCodec[HumanInvestment] = DeriveJsonCodec.gen[HumanInvestment]
+  implicit val operationalInvestmentCodec: JsonCodec[OperationalInvestment] = DeriveJsonCodec.gen[OperationalInvestment]
+}

--- a/core/src/main/scala/entystal/model/Liability.scala
+++ b/core/src/main/scala/entystal/model/Liability.scala
@@ -1,0 +1,34 @@
+package entystal.model
+
+trait Liability {
+  def id: String
+  def timestamp: Long
+  def amount: BigDecimal
+}
+
+final case class BasicLiability(
+    id: String,
+    amount: BigDecimal,
+    timestamp: Long
+) extends Liability
+
+final case class EthicalLiability(
+    id: String,
+    description: String,
+    timestamp: Long,
+    amount: BigDecimal
+) extends Liability
+
+final case class StrategicLiability(
+    id: String,
+    reason: String,
+    timestamp: Long,
+    amount: BigDecimal
+) extends Liability
+
+final case class LegalLiability(
+    id: String,
+    law: String,
+    timestamp: Long,
+    amount: BigDecimal
+) extends Liability

--- a/core/src/test/scala/entystal/EntystalModuleSpec.scala
+++ b/core/src/test/scala/entystal/EntystalModuleSpec.scala
@@ -1,0 +1,15 @@
+package entystal
+
+import zio.test.{ZIOSpecDefault, assertTrue, Spec, TestEnvironment}
+
+object EntystalModuleSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("EntystalModuleSpec")(
+      test("la capa proporciona un ledger vac\u00edo") {
+        for {
+          ledger   <- EntystalModule.layer.build.map(_.get)
+          history  <- ledger.getHistory
+        } yield assertTrue(history.isEmpty)
+      }
+    )
+}

--- a/core/src/test/scala/entystal/ledger/LedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/LedgerSpec.scala
@@ -1,0 +1,18 @@
+package entystal.ledger
+
+import entystal.model.DataAsset
+import zio.test.{ZIOSpecDefault, assertTrue, Spec, TestEnvironment}
+
+object LedgerSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("LedgerSpec")(
+      test("Registra y recupera activos correctamente") {
+        val asset = DataAsset("id-1", "Datos relevantes", 1L, BigDecimal(42))
+        for {
+          ledger  <- InMemoryLedger.live.build.map(_.get)
+          _       <- ledger.recordAsset(asset)
+          history <- ledger.getHistory
+        } yield assertTrue(history.contains(AssetEntry(asset)))
+      }
+    )
+}

--- a/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
@@ -1,0 +1,33 @@
+package entystal.ledger
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import doobie.util.transactor.Transactor
+import entystal.model._
+
+/** Pruebas de integración del SqlLedger usando PostgreSQL */
+object SqlLedgerSpec extends ZIOSpecDefault {
+  private val transactorLayer = ZLayer.scoped {
+    ZIO.attempt {
+      Transactor.fromDriverManager[Task](
+        "org.postgresql.Driver",
+        "jdbc:postgresql://localhost:5432/entystal",
+        "postgres",
+        "password"
+      )
+    }
+  }
+
+  override def spec = suite("SqlLedgerSpec")(
+    test("Registra y recupera un activo persistente") {
+      val asset = DataAsset("id-psql-1", "Activo PSQL", 123L, BigDecimal(99))
+      for {
+        xa     <- ZIO.service[Transactor[Task]]
+        ledger  = new SqlLedger(xa)
+        _      <- ledger.recordAsset(asset)
+        // TODO: implementar getHistory y verificar contenido
+      } yield assertCompletes
+    }
+  ).provideLayerShared(transactorLayer)
+}

--- a/core/src/test/scala/entystal/model/AssetSpec.scala
+++ b/core/src/test/scala/entystal/model/AssetSpec.scala
@@ -1,0 +1,11 @@
+package entystal.model
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AssetSpec extends AnyFlatSpec with Matchers {
+  "Un DataAsset" should "mantener su valor" in {
+    val asset = DataAsset("a1", "info", 1L, BigDecimal(100))
+    asset.value shouldBe BigDecimal(100)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
## Resumen
- incluye script `entystal_schema.sql` para PostgreSQL
- añade `SqlLedgerSpec` con capa de transactor
- documenta uso de la CLI y pasos de base en los README

## Testing
- `sbt scalafmtAll` *(falló: command not found)*
- `sbt test` *(falló: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685c243026c0832b9dd6df71b9142a4a