### PR TITLE
Añade guía y script para instalar sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Revisa la carpeta `core/` para el módulo principal.
 
 ## Uso
 
-Requiere [sbt](https://www.scala-sbt.org/) instalado.
+Necesitas tener Java (JDK) y [sbt](https://www.scala-sbt.org/) instalados.
+Si no cuentas con sbt, revisa [docs/setup-sbt.md](docs/setup-sbt.md).
 
 ```bash
 sbt scalafmtAll   # Formateo de código

--- a/core/README.md
+++ b/core/README.md
@@ -3,6 +3,8 @@
 Sistema funcional en Scala para trazabilidad ética, balance y registro auditable de recursos en proyectos colaborativos.
 Incluye modelos de activos, pasivos e inversiones, ledger funcional concurrente y persistencia opcional en PostgreSQL.
 
+Para compilar necesitas Java (JDK) y sbt. Consulta [../docs/setup-sbt.md](../docs/setup-sbt.md) si aún no los tienes instalados.
+
 ## Uso rápido
 1. Clona el repo y lanza `sbt compile`.
 2. Configura PostgreSQL y ejecuta el script `core/sql/entystal_schema.sql`.

--- a/docs/setup-sbt.md
+++ b/docs/setup-sbt.md
@@ -1,0 +1,35 @@
+# Instalación de sbt
+
+Para compilar y ejecutar este proyecto necesitas **Java (JDK)** y [sbt](https://www.scala-sbt.org/).
+
+## Linux
+
+En sistemas Debian o Ubuntu puedes ejecutar el script `scripts/install_sbt.sh` incluido en este repositorio:
+
+```bash
+bash scripts/install_sbt.sh
+```
+
+También puedes seguir los pasos manuales:
+
+1. Importa la clave GPG del repositorio oficial de sbt.
+2. Añade el repositorio a tus fuentes de paquetes.
+3. Actualiza e instala sbt con `apt`.
+
+## macOS
+
+Si utilizas [Homebrew](https://brew.sh/):
+
+```bash
+brew install sbt
+```
+
+## Windows
+
+Descarga el instalador desde la [página oficial de sbt](https://www.scala-sbt.org/download.html) y ejecútalo.
+
+Tras la instalación, comprueba la versión con:
+
+```bash
+sbt --version
+```

--- a/scripts/install_sbt.sh
+++ b/scripts/install_sbt.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Instalador simple de sbt para Debian/Ubuntu
+set -e
+
+sudo apt-get update
+sudo apt-get install -y curl gnupg
+
+curl -sL https://repo.scala-sbt.org/scalasbt/repo.gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/sbt-release.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/sbt-release.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" | \
+  sudo tee /etc/apt/sources.list.d/sbt.list
+
+echo "deb [signed-by=/usr/share/keyrings/sbt-release.gpg] https://repo.scala-sbt.org/scalasbt/debian /" | \
+  sudo tee /etc/apt/sources.list.d/sbt_old.list
+
+sudo apt-get update
+sudo apt-get install -y sbt


### PR DESCRIPTION
## Resumen
- documenta instalación de sbt para Linux, macOS y Windows
- enlaza esta guía desde ambos README
- agrega script de instalación para Debian/Ubuntu

## Testing
- `sbt test` *(falló: sbt no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_6860c3e01a3c832b98be06581a1c704b