### PR TITLE
Añade guías de contribución y hook de pre-commit

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,20 @@
+name: Scala CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:17
+      - name: Formateo y pruebas
+        run: |
+          sbt scalafmtAll
+          sbt test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Guía de contribución
+
+## Preparación
+Ejecuta antes de cada commit:
+
+```bash
+sbt scalafmtAll
+sbt test
+```
+
+Esto asegura un formato uniforme y pruebas en verde.
+
+## Revisión
+Revisa tu diff buscando marcas de conflicto como `<<<<<<<` o `>>>>>>>` y resuélvelas antes de confirmar.
+
+## Pull Request
+1. Verifica que los comandos de preparación no generen errores.
+2. Asegúrate de que no existen marcas de conflicto.
+3. Actualiza tu rama con `main`.
+4. Abre un PR limpio y describe brevemente tus cambios.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ sbt "core/run --mode asset --assetId id-101 --assetDesc 'Datos relevantes CLI'"
 ```
 
 Antes, configura PostgreSQL con `core/sql/entystal_schema.sql` si vas a usar `SqlLedger`.
+
+## Hook de Git
+
+Para habilitar el hook de pre-commit:
+
+```bash
+ln -s ../../scripts/pre-commit .git/hooks/pre-commit
+```
+
+## Integración continua
+
+Este repositorio cuenta con un flujo de GitHub Actions que ejecuta `sbt scalafmtAll` y `sbt test` en cada push.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+sbt scalafmtAll
+sbt test
+
+if grep -R "<<<<<<<" .; then
+  echo "Se encontraron marcas de conflicto"
+  exit 1
+fi


### PR DESCRIPTION
## Resumen
- documentar proceso de contribución
- crear hook de pre-commit con sbt scalafmtAll y test
- explicar en README cómo habilitar el hook
- añadir flujo de GitHub Actions para formateo y pruebas

## Checklist
- [ ] Lint pasando sin errores
- [ ] Coverage ≥ 90%
- [ ] Sin vulnerabilidades críticas
- [ ] UI revisada y accesible
- [ ] Informe generado publicado en GitHub

------
https://chatgpt.com/codex/tasks/task_e_6860c3e06294832ba5e6ed99b343bfe3