### PR TITLE
Soporte de pasivos e inversiones en CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ La salida debería mostrar algo similar a:
 Registrado activo: DataAsset(id-101, Datos relevantes CLI, 172xxxxxxx, 1)
 ```
 
+Para registrar un pasivo o una inversión:
+
+```bash
+sbt "core/run --mode liability --assetId liab-1 --liabilityDesc 'Multa legal'"
+```
+
+```bash
+sbt "core/run --mode investment --assetId inv-1 --investmentQty 5"
+```
+
 Antes, configura PostgreSQL con `core/sql/entystal_schema.sql` si vas a usar `SqlLedger`.
 
 ## Contribución


### PR DESCRIPTION
## Resumen
- ampliar `Config` con campos para pasivo e inversión
- registrar pasivos e inversiones en el `Ledger`
- agregar ejemplos de uso en `README`

## Testing
- `sbt` no está disponible en el entorno, por lo que la compilación y pruebas no pudieron ejecutarse

------
https://chatgpt.com/codex/tasks/task_e_68658ea7e468832baf34cd321b7b7a9a