### PR TITLE
Actualiza SqlLedgerSpec y README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ La salida debería mostrar algo similar a:
 Registrado activo: DataAsset(id-101, Datos relevantes CLI, 172xxxxxxx, 1)
 ```
 
+
 Antes, configura PostgreSQL con `core/sql/entystal_schema.sql` si vas a usar `SqlLedger`.
+
+## Pruebas de integración
+
+Las pruebas que ejercitan `SqlLedger` leen las credenciales de la base de datos
+desde las variables de entorno `PGUSER` y `PGPASSWORD`. Configúralas antes de
+ejecutar:
+
+```bash
+sbt test
+```
 
 ## Contribución
 

--- a/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
@@ -8,13 +8,16 @@ import entystal.model._
 
 /** Pruebas de integración del SqlLedger usando PostgreSQL */
 object SqlLedgerSpec extends ZIOSpecDefault {
+  private val dbUser = sys.env.getOrElse("PGUSER", "postgres")
+  private val dbPass = sys.env.getOrElse("PGPASSWORD", "password")
+
   private val transactorLayer = ZLayer.scoped {
     ZIO.attempt {
       Transactor.fromDriverManager[Task](
         "org.postgresql.Driver",
         "jdbc:postgresql://localhost:5432/entystal",
-        "postgres",
-        "password"
+        dbUser,
+        dbPass
       )
     }
   }


### PR DESCRIPTION
## Resumen
- SqlLedgerSpec ahora lee `PGUSER` y `PGPASSWORD` desde `sys.env`
- README documenta variables de entorno para las pruebas de integración

## Checklist
- [ ] Lint pasando sin errores
- [ ] Coverage ≥ 90%
- [ ] Sin vulnerabilidades críticas
- [ ] UI revisada y accesible
- [ ] Informe generado publicado en GitHub

------
https://chatgpt.com/codex/tasks/task_e_68658eaac4d0832ba5e8de6aeaa2cde8