### PR TITLE
Añadir pruebas de CLI y Balance

### DIFF
--- a/core/src/test/scala/entystal/cli/MainSpec.scala
+++ b/core/src/test/scala/entystal/cli/MainSpec.scala
@@ -1,0 +1,35 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.cli.{Main, Config}
+import scopt.OParser
+import entystal.model._
+
+class MainSpec extends AnyFlatSpec with Matchers {
+  private def parse(args: Array[String]): Config =
+    OParser.parse(Main.parser, args, Config()).get
+
+  "La CLI" should "construir un DataAsset con argumentos validos" in {
+    val cfg = parse(Array("--mode", "asset", "--assetId", "a1", "--assetDesc", "dato"))
+    val ts = 1L
+    val asset = DataAsset(cfg.assetId.get, cfg.assetDesc.get, ts, BigDecimal(1))
+    asset.id shouldBe "a1"
+    asset.data shouldBe "dato"
+    asset.value shouldBe BigDecimal(1)
+  }
+
+  it should "construir un BasicLiability cambiando el modo" in {
+    val cfg = parse(Array("--mode", "liability", "--assetId", "l1", "--assetDesc", "pago"))
+    val ts = 2L
+    val liability = BasicLiability(cfg.assetId.get, BigDecimal(1), ts)
+    liability.id shouldBe "l1"
+    liability.amount shouldBe BigDecimal(1)
+  }
+
+  it should "construir un BasicInvestment cambiando el modo" in {
+    val cfg = parse(Array("--mode", "investment", "--assetId", "i1", "--assetDesc", "inv"))
+    val ts = 3L
+    val investment = BasicInvestment(cfg.assetId.get, BigDecimal(1), ts)
+    investment.id shouldBe "i1"
+    investment.quantity shouldBe BigDecimal(1)
+  }
+}

--- a/core/src/test/scala/entystal/model/BalanceSpec.scala
+++ b/core/src/test/scala/entystal/model/BalanceSpec.scala
@@ -1,0 +1,21 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.model._
+
+class BalanceSpec extends AnyFlatSpec with Matchers {
+  "netWorth" should "calcularse correctamente" in {
+    val assets = List(
+      DataAsset("a1", "d1", 1L, BigDecimal(10)),
+      DataAsset("a2", "d2", 2L, BigDecimal(5))
+    )
+    val liabilities = List(
+      BasicLiability("l1", BigDecimal(4), 3L)
+    )
+    val balance = Balance(assets, liabilities)
+    balance.netWorth shouldBe BigDecimal(11)
+  }
+
+  it should "soportar listas vacías" in {
+    Balance(Nil, Nil).netWorth shouldBe BigDecimal(0)
+  }
+}


### PR DESCRIPTION
## Resumen
- se añade `MainSpec` para probar la construcción de registros por CLI
- se crea `BalanceSpec` verificando el cálculo de `netWorth`

## Testing
- `sbt test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68658eb0e988832ba10002e25c0cc133