### PR TITLE
Skip SqlLedgerSpec when PostgreSQL is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ ejecutar:
 sbt test
 ```
 
+Estas pruebas se ejecutan solo si PostgreSQL está activo y accesible en
+`localhost:5432`. Si no es así se marcan como **ignoradas** automáticamente.
+
 ## Contribución
 
 Para detalles sobre cómo enviar cambios sin conflictos revisa [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- verifica la conexión a PostgreSQL antes de crear el `Transactor`
- salta `SqlLedgerSpec` cuando la base de datos no responde
- aclara en la documentación que estas pruebas se ejecutan solo con PostgreSQL activo

## Testing
- `bash scripts/install_sbt.sh`
- `sbt test` *(falla la compilación de `SqlLedger.scala`)*

------
https://chatgpt.com/codex/tasks/task_e_6865ae189af4832bb12dd64705be9a02