### PR TITLE
Configura sbt en workflow de Scala

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: coursier/setup-action@v1
         with:
           jvm: temurin:17
+          apps: sbt
       - name: Instalar cliente PostgreSQL
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Inicializar base de datos


### PR DESCRIPTION
## Resumen
- añade `apps: sbt` en el paso de `coursier/setup-action` de `scala.yml`

## Testing
- `apt-get update`
- `apt-get install -y openjdk-17-jdk`
- `cs install sbt` *(falló: `Network is unreachable`)*

------
https://chatgpt.com/codex/tasks/task_e_6866c1fab7c0832ba61defb8110a8771