### PR TITLE
Agregar GUI con ScalaFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ listo en tu sistema.
 ```bash
 sbt scalafmtAll   # Formateo de código
 sbt test          # Ejecutar pruebas
+sbt "core/runMain entystal.gui.GuiApp"  # Lanzar la interfaz gráfica
 ```
 
 Ejemplo de registro por CLI:

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,9 @@ lazy val core = (project in file("core"))
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,
       "dev.zio" %% "zio-test"     % "2.0.15" % Test,
       "dev.zio" %% "zio-test-sbt" % "2.0.15" % Test,
-      "com.github.scopt" %% "scopt" % "4.1.0"
+      "com.github.scopt" %% "scopt" % "4.1.0",
+      "org.scalafx" %% "scalafx" % "21.0.0-R32",
+      "org.scalafx" %% "scalafxml-core-sfx8" % "0.5"
     ),
     scalacOptions ++= Seq(
       "-deprecation",

--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -1,0 +1,28 @@
+package entystal.gui
+
+import scalafx.application.JFXApp3
+import scalafx.stage.Stage
+import entystal.{EntystalModule}
+import entystal.ledger.Ledger
+import entystal.viewmodel.RegistroViewModel
+import entystal.view.MainView
+import zio.Runtime
+
+/** Lanzador principal de la interfaz gráfica */
+object GuiApp extends JFXApp3 {
+  override def start(): Unit = {
+    implicit val runtime: Runtime[Any] = Runtime.default
+    val ledger: Ledger                 = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get)))
+        .getOrThrow()
+    }
+    val vm                             = new RegistroViewModel(ledger)
+    val view                           = new MainView(vm)
+
+    stage = new JFXApp3.PrimaryStage {
+      title = "Entystal GUI"
+      scene = view.scene
+    }
+  }
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -1,0 +1,62 @@
+package entystal.view
+
+import scalafx.scene.Scene
+import scalafx.scene.control.{Button, ChoiceBox, Label, TextField}
+import scalafx.scene.layout.{GridPane, VBox}
+import scalafx.collections.ObservableBuffer
+import scalafx.Includes._
+import scalafx.geometry.Insets
+import entystal.viewmodel.RegistroViewModel
+
+/** Vista principal de registro */
+class MainView(vm: RegistroViewModel) {
+  private val labelDescripcion = new Label("Descripción")
+
+  private val tipoChoice =
+    new ChoiceBox[String](ObservableBuffer("activo", "pasivo", "inversion")) {
+      value <==> vm.tipo
+    }
+
+  private val idField = new TextField() {
+    text <==> vm.identificador
+    promptText = "ID"
+  }
+
+  private val descField = new TextField() {
+    text <==> vm.descripcion
+    promptText = "Descripción o cantidad"
+  }
+
+  private val mensajeLabel = new Label()
+
+  private val registrarBtn = new Button("Registrar") {
+    disable <== vm.puedeRegistrar.not()
+    onAction = _ => mensajeLabel.text = vm.registrar()
+  }
+
+  tipoChoice.value.onChange { (_, _, nv) =>
+    labelDescripcion.text = if (nv == "inversion") "Cantidad" else "Descripción"
+  }
+
+  val rootPane = new VBox(10) {
+    padding = Insets(20)
+    children = Seq(
+      new GridPane {
+        hgap = 10
+        vgap = 10
+        add(new Label("Tipo"), 0, 0)
+        add(tipoChoice, 1, 0)
+        add(new Label("ID"), 0, 1)
+        add(idField, 1, 1)
+        add(labelDescripcion, 0, 2)
+        add(descField, 1, 2)
+      },
+      registrarBtn,
+      mensajeLabel
+    )
+  }
+
+  val scene = new Scene(400, 200) {
+    root = rootPane
+  }
+}

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -1,0 +1,61 @@
+package entystal.viewmodel
+
+import scalafx.beans.property.{StringProperty, ObjectProperty}
+import scalafx.beans.binding.{BooleanBinding, Bindings}
+import entystal.model._
+import entystal.ledger.Ledger
+import zio.Runtime
+
+/** ViewModel para el formulario de registro */
+class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
+  val tipo          = StringProperty("activo")
+  val identificador = StringProperty("")
+  val descripcion   = StringProperty("")
+
+  /** Validación reactiva de los campos */
+  val puedeRegistrar: BooleanBinding = Bindings.createBooleanBinding(
+    () => {
+      val idOk   = identificador.value.trim.nonEmpty
+      val descOk = descripcion.value.trim.nonEmpty
+      val qtyOk  = !tipo.value.equalsIgnoreCase("inversion") ||
+        descripcion.value.matches("^\\d+(\\.\\d+)?$")
+      idOk && descOk && qtyOk
+    },
+    identificador,
+    descripcion,
+    tipo
+  )
+
+  /** Devuelve mensaje de error o confirma el registro */
+  def registrar(): String = {
+    if (!puedeRegistrar.value) {
+      if (identificador.value.trim.isEmpty)
+        return "ID requerido"
+      if (descripcion.value.trim.isEmpty)
+        return if (tipo.value == "inversion") "Cantidad requerida" else "Descripción requerida"
+      if (tipo.value == "inversion" && !descripcion.value.matches("^\\d+(\\.\\d+)?$"))
+        return "La cantidad debe ser numérica"
+    }
+
+    val ts = System.currentTimeMillis
+    tipo.value match {
+      case "activo" =>
+        val asset = DataAsset(identificador.value, descripcion.value, ts, BigDecimal(1))
+        zio.Unsafe.unsafe { implicit u =>
+          runtime.unsafe.run(ledger.recordAsset(asset)).getOrThrow()
+        }
+      case "pasivo" =>
+        val liability = EthicalLiability(identificador.value, descripcion.value, ts, BigDecimal(1))
+        zio.Unsafe.unsafe { implicit u =>
+          runtime.unsafe.run(ledger.recordLiability(liability)).getOrThrow()
+        }
+      case _        =>
+        val qty        = BigDecimal(descripcion.value)
+        val investment = BasicInvestment(identificador.value, qty, ts)
+        zio.Unsafe.unsafe { implicit u =>
+          runtime.unsafe.run(ledger.recordInvestment(investment)).getOrThrow()
+        }
+    }
+    "Registro completado"
+  }
+}


### PR DESCRIPTION
## Resumen
- Se añaden dependencias de ScalaFX y ScalaFXML
- Nueva clase `RegistroViewModel` con validaciones reactivas
- Vista principal `MainView` con campos y botón de registro
- Lanzador `GuiApp` para ejecutar la GUI
- Instrucciones actualizadas en README

## Testing
- `sbt scalafmtAll`
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6866d6017438832bbefb31365d3a2360