### PR TITLE
Mejoras de accesibilidad en GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ El código principal se encuentra en la carpeta `core/` y está organizado en m�
 - Interfaz gráfica (GUI) básica con ScalaFX para registrar activos, pasivos e inversiones.
 - Generación de JAR ejecutable mediante `sbt-assembly`.
 
+## Accesibilidad
+
+La GUI ahora define texto accesible (`accessibleText`) en cada botón y campo,
+atajos de teclado mediante `mnemonicParsing` para las acciones principales y un
+orden de tabulación lógico para navegar sólo con el teclado.
+
 ## Requisitos
 
 - Java JDK 8 o superior.

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -10,28 +10,39 @@ import entystal.viewmodel.RegistroViewModel
 
 /** Vista principal de registro */
 class MainView(vm: RegistroViewModel) {
-  private val labelDescripcion = new Label("Descripción")
+  private val labelDescripcion = new Label("Descripción") {
+    accessibleText = "Etiqueta descripción"
+  }
 
   private val tipoChoice =
     new ChoiceBox[String](ObservableBuffer("activo", "pasivo", "inversion")) {
       value <==> vm.tipo
+      accessibleText = "Tipo de registro"
+      focusTraversable = true
     }
 
   private val idField = new TextField() {
     text <==> vm.identificador
     promptText = "ID"
+    accessibleText = "Identificador"
+    focusTraversable = true
   }
 
   private val descField = new TextField() {
     text <==> vm.descripcion
     promptText = "Descripción o cantidad"
+    accessibleText = "Descripción o cantidad"
+    focusTraversable = true
   }
 
   private val mensajeLabel = new Label()
 
-  private val registrarBtn = new Button("Registrar") {
+  private val registrarBtn = new Button("_Registrar") {
+    mnemonicParsing = true
+    accessibleText = "Registrar datos"
     disable <== vm.puedeRegistrar.not()
     onAction = _ => mensajeLabel.text = vm.registrar()
+    focusTraversable = true
   }
 
   tipoChoice.value.onChange { (_, _, nv) =>


### PR DESCRIPTION
## Resumen
- se añaden textos accesibles y tabulación a los controles de `MainView`
- se habilita `mnemonicParsing` con atajo Alt+R para el botón Registrar
- se documentan estos cambios en `README`

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_6867e75056c0832b83ebb924f2673649