### PR TITLE
Añade exportadores CSV y PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+target/
+project/target/
+core/target/
+.project
+.idea
+
+project/project/

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ lazy val core = (project in file("core"))
       "org.openjfx" % "javafx-swing" % javafxVersion classifier "linux",
       "org.openjfx" % "javafx-web" % javafxVersion classifier "linux",
       "org.scalafx" %% "scalafx" % "21.0.0-R32",
-      "org.scalafx" %% "scalafxml-core-sfx8" % "0.5"
+      "org.scalafx" %% "scalafxml-core-sfx8" % "0.5",
+      "org.apache.pdfbox" % "pdfbox" % "2.0.30"
       ),
     scalacOptions ++= Seq(
       "-deprecation",

--- a/core/src/main/scala/entystal/util/CsvExporter.scala
+++ b/core/src/main/scala/entystal/util/CsvExporter.scala
@@ -1,0 +1,41 @@
+package entystal.util
+
+import entystal.ledger._
+import entystal.model._
+import zio.{Task, ZIO}
+
+/** Utilidad para exportar el historial del ledger a un fichero CSV */
+object CsvExporter {
+  def save(entries: List[LedgerEntry], path: String): Task[Unit] =
+    ZIO.attempt {
+      val writer = new java.io.PrintWriter(new java.io.File(path))
+      try {
+        writer.println("type,id,description,timestamp")
+        entries.foreach {
+          case AssetEntry(asset) =>
+            val desc = asset match {
+              case DataAsset(_, data, _, _)        => data
+              case CodeAsset(_, repo, _, _)        => repo
+              case ReputationAsset(_, score, _, _) => s"score: $score"
+            }
+            writer.println(s"asset,${asset.id},$desc,${asset.timestamp}")
+          case LiabilityEntry(liability) =>
+            val desc = liability match {
+              case BasicLiability(_, _, _)          => "basic"
+              case EthicalLiability(_, d, _, _)     => d
+              case StrategicLiability(_, r, _, _)   => r
+              case LegalLiability(_, l, _, _)       => l
+            }
+            writer.println(s"liability,${liability.id},$desc,${liability.timestamp}")
+          case InvestmentEntry(investment) =>
+            val desc = investment match {
+              case BasicInvestment(_, q, _)       => q.toString
+              case EconomicInvestment(_, q, _)    => q.toString
+              case HumanInvestment(_, q, _)       => q.toString
+              case OperationalInvestment(_, q, _) => q.toString
+            }
+            writer.println(s"investment,${investment.id},$desc,${investment.timestamp}")
+        }
+      } finally writer.close()
+    }
+}

--- a/core/src/main/scala/entystal/util/PdfExporter.scala
+++ b/core/src/main/scala/entystal/util/PdfExporter.scala
@@ -1,0 +1,39 @@
+package entystal.util
+
+import entystal.ledger._
+import entystal.model._
+import zio.{Task, ZIO}
+import org.apache.pdfbox.pdmodel.{PDDocument, PDPage}
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+
+/** Utilidad para exportar el historial del ledger a un PDF sencillo */
+object PdfExporter {
+  def save(entries: List[LedgerEntry], path: String): Task[Unit] =
+    ZIO.attempt {
+      val doc  = new PDDocument()
+      val page = new PDPage(PDRectangle.LETTER)
+      doc.addPage(page)
+      val stream = new PDPageContentStream(doc, page)
+      try {
+        stream.beginText()
+        stream.setFont(PDType1Font.HELVETICA, 12)
+        stream.newLineAtOffset(50, page.getMediaBox.getHeight - 50)
+        entries.zipWithIndex.foreach { case (e, idx) =>
+          val line = e match {
+            case AssetEntry(asset)       => s"Asset: ${asset.id}"
+            case LiabilityEntry(liab)    => s"Liability: ${liab.id}"
+            case InvestmentEntry(inv)    => s"Investment: ${inv.id}"
+          }
+          if (idx > 0) stream.newLineAtOffset(0, -15)
+          stream.showText(line)
+        }
+        stream.endText()
+      } finally {
+        stream.close()
+        doc.save(path)
+        doc.close()
+      }
+    }
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -34,6 +34,14 @@ class MainView(vm: RegistroViewModel) {
     onAction = _ => mensajeLabel.text = vm.registrar()
   }
 
+  private val exportCsvBtn = new Button("Exportar CSV") {
+    onAction = _ => mensajeLabel.text = vm.exportCsv()
+  }
+
+  private val exportPdfBtn = new Button("Exportar PDF") {
+    onAction = _ => mensajeLabel.text = vm.exportPdf()
+  }
+
   tipoChoice.value.onChange { (_, _, nv) =>
     labelDescripcion.text = if (nv == "inversion") "Cantidad" else "Descripción"
   }
@@ -52,6 +60,9 @@ class MainView(vm: RegistroViewModel) {
         add(descField, 1, 2)
       },
       registrarBtn,
+      new VBox(5) {
+        children = Seq(exportCsvBtn, exportPdfBtn)
+      },
       mensajeLabel
     )
   }

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -4,6 +4,7 @@ import scalafx.beans.property.{StringProperty, ObjectProperty}
 import scalafx.beans.binding.{BooleanBinding, Bindings}
 import entystal.model._
 import entystal.ledger.Ledger
+import entystal.util.{CsvExporter, PdfExporter}
 import zio.Runtime
 
 /** ViewModel para el formulario de registro */
@@ -57,5 +58,27 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
         }
     }
     "Registro completado"
+  }
+
+  /** Exporta el historial a CSV y devuelve mensaje de confirmación */
+  def exportCsv(path: String = "ledger.csv"): String = {
+    val entries = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ledger.getHistory).getOrThrow()
+    }
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(CsvExporter.save(entries, path)).getOrThrow()
+    }
+    s"CSV exportado en $path"
+  }
+
+  /** Exporta el historial a PDF y devuelve mensaje de confirmación */
+  def exportPdf(path: String = "ledger.pdf"): String = {
+    val entries = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ledger.getHistory).getOrThrow()
+    }
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(PdfExporter.save(entries, path)).getOrThrow()
+    }
+    s"PDF exportado en $path"
   }
 }

--- a/core/src/test/scala/entystal/util/CsvExporterSpec.scala
+++ b/core/src/test/scala/entystal/util/CsvExporterSpec.scala
@@ -1,0 +1,23 @@
+package entystal.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.model._
+import entystal.ledger._
+import zio.Runtime
+
+class CsvExporterSpec extends AnyFlatSpec with Matchers {
+  "CsvExporter" should "generar un fichero con cabecera" in {
+    val entries = List(AssetEntry(DataAsset("a1", "info", 1L, BigDecimal(1))))
+    val tmp     = java.nio.file.Files.createTempFile("hist", ".csv")
+    val rt = Runtime.default
+    zio.Unsafe.unsafe { implicit u =>
+      rt.unsafe
+        .run(CsvExporter.save(entries, tmp.toString))
+        .getOrThrow()
+    }
+    val lines = scala.io.Source.fromFile(tmp.toFile).getLines().toList
+    lines.head shouldBe "type,id,description,timestamp"
+    tmp.toFile.delete()
+  }
+}

--- a/core/src/test/scala/entystal/util/PdfExporterSpec.scala
+++ b/core/src/test/scala/entystal/util/PdfExporterSpec.scala
@@ -1,0 +1,24 @@
+package entystal.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.model._
+import entystal.ledger._
+import org.apache.pdfbox.pdmodel.PDDocument
+import zio.Runtime
+
+class PdfExporterSpec extends AnyFlatSpec with Matchers {
+  "PdfExporter" should "crear un PDF no vacío" in {
+    val entries = List(LiabilityEntry(BasicLiability("l1", BigDecimal(1), 2L)))
+    val tmp     = java.nio.file.Files.createTempFile("hist", ".pdf")
+    val rt = Runtime.default
+    zio.Unsafe.unsafe { implicit u =>
+      rt.unsafe
+        .run(PdfExporter.save(entries, tmp.toString))
+        .getOrThrow()
+    }
+    val doc = PDDocument.load(tmp.toFile)
+    try doc.getNumberOfPages should be > 0
+    finally { doc.close(); tmp.toFile.delete() }
+  }
+}


### PR DESCRIPTION
## Resumen
- se incluye Apache PDFBox en `build.sbt`
- utilidades `CsvExporter` y `PdfExporter`
- botones de exportación en la interfaz ScalaFX
- pruebas unitarias de los nuevos exportadores

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6867e74e0598832b8d96bf0e4ba29ffa