### PR TITLE
Implementación de i18n con cambio dinámico de idioma

### DIFF
--- a/core/src/main/resources/i18n/messages_en.properties
+++ b/core/src/main/resources/i18n/messages_en.properties
@@ -1,0 +1,13 @@
+app.title=Entystal GUI
+label.tipo=Type
+label.id=ID
+label.descripcion=Description
+label.cantidad=Amount
+prompt.id=ID
+prompt.desc=Description or amount
+button.registrar=Register
+mensaje.registroCompletado=Registration completed
+error.idRequerido=ID required
+error.descripcionRequerida=Description required
+error.cantidadRequerida=Amount required
+error.cantidadNumerica=Amount must be numeric

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -1,0 +1,13 @@
+app.title=Entystal GUI
+label.tipo=Tipo
+label.id=ID
+label.descripcion=Descripción
+label.cantidad=Cantidad
+prompt.id=ID
+prompt.desc=Descripción o cantidad
+button.registrar=Registrar
+mensaje.registroCompletado=Registro completado
+error.idRequerido=ID requerido
+error.descripcionRequerida=Descripción requerida
+error.cantidadRequerida=Cantidad requerida
+error.cantidadNumerica=La cantidad debe ser numérica

--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -6,6 +6,7 @@ import entystal.{EntystalModule}
 import entystal.ledger.Ledger
 import entystal.viewmodel.RegistroViewModel
 import entystal.view.MainView
+import entystal.i18n.I18n
 import zio.Runtime
 
 /** Lanzador principal de la interfaz gráfica */
@@ -21,8 +22,9 @@ object GuiApp extends JFXApp3 {
     val view                           = new MainView(vm)
 
     stage = new JFXApp3.PrimaryStage {
-      title = "Entystal GUI"
+      title = I18n("app.title")
       scene = view.scene
     }
+    I18n.register(() => stage.title = I18n("app.title"))
   }
 }

--- a/core/src/main/scala/entystal/i18n/I18n.scala
+++ b/core/src/main/scala/entystal/i18n/I18n.scala
@@ -1,0 +1,34 @@
+package entystal.i18n
+
+import scalafx.beans.property.{ObjectProperty, StringProperty}
+import java.util.{Locale, ResourceBundle}
+
+/** Utilidad sencilla para manejar traducciones mediante ResourceBundle */
+object I18n {
+  val locale: ObjectProperty[Locale] = ObjectProperty(Locale.getDefault)
+
+  private var bundle: ResourceBundle =
+    ResourceBundle.getBundle("i18n/messages", locale.value)
+
+  private var listeners = List.empty[() => Unit]
+
+  /** Obtiene el texto traducido para la clave dada */
+  def apply(key: String): String = bundle.getString(key)
+
+  /** Propiedad que se actualiza cuando cambia el locale */
+  def binding(key: String): StringProperty = {
+    val prop = StringProperty(apply(key))
+    register(() => prop.value = apply(key))
+    prop
+  }
+
+  /** Cambia el locale activo y notifica a las vistas */
+  def setLocale(loc: Locale): Unit = {
+    locale.value = loc
+    bundle = ResourceBundle.getBundle("i18n/messages", loc)
+    listeners.foreach(_())
+  }
+
+  /** Permite que una vista sea notificada al cambiar el idioma */
+  def register(l: () => Unit): Unit = listeners = l :: listeners
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -7,10 +7,18 @@ import scalafx.collections.ObservableBuffer
 import scalafx.Includes._
 import scalafx.geometry.Insets
 import entystal.viewmodel.RegistroViewModel
+import entystal.i18n.I18n
+import java.util.Locale
 
 /** Vista principal de registro */
 class MainView(vm: RegistroViewModel) {
-  private val labelDescripcion = new Label("Descripción")
+  private val labelTipo        = new Label()
+  private val labelId          = new Label()
+  private val labelDescripcion = new Label()
+  private val langChoice =
+    new ChoiceBox[String](ObservableBuffer("es", "en")) {
+      value = I18n.locale.value.getLanguage
+    }
 
   private val tipoChoice =
     new ChoiceBox[String](ObservableBuffer("activo", "pasivo", "inversion")) {
@@ -19,24 +27,42 @@ class MainView(vm: RegistroViewModel) {
 
   private val idField = new TextField() {
     text <==> vm.identificador
-    promptText = "ID"
+    promptText = I18n("prompt.id")
   }
 
   private val descField = new TextField() {
     text <==> vm.descripcion
-    promptText = "Descripción o cantidad"
+    promptText = I18n("prompt.desc")
   }
 
   private val mensajeLabel = new Label()
 
-  private val registrarBtn = new Button("Registrar") {
+  private val registrarBtn = new Button() {
     disable <== vm.puedeRegistrar.not()
     onAction = _ => mensajeLabel.text = vm.registrar()
   }
 
   tipoChoice.value.onChange { (_, _, nv) =>
-    labelDescripcion.text = if (nv == "inversion") "Cantidad" else "Descripción"
+    updateTexts()
   }
+
+  langChoice.value.onChange { (_, _, nv) =>
+    if (nv != null) I18n.setLocale(Locale.forLanguageTag(nv))
+  }
+
+  private def updateTexts(): Unit = {
+    labelTipo.text = I18n("label.tipo")
+    labelId.text = I18n("label.id")
+    labelDescripcion.text =
+      if (tipoChoice.value == "inversion") I18n("label.cantidad")
+      else I18n("label.descripcion")
+    idField.promptText = I18n("prompt.id")
+    descField.promptText = I18n("prompt.desc")
+    registrarBtn.text = I18n("button.registrar")
+  }
+
+  I18n.register(() => updateTexts())
+  updateTexts()
 
   val rootPane = new VBox(10) {
     padding = Insets(20)
@@ -44,13 +70,14 @@ class MainView(vm: RegistroViewModel) {
       new GridPane {
         hgap = 10
         vgap = 10
-        add(new Label("Tipo"), 0, 0)
+        add(labelTipo, 0, 0)
         add(tipoChoice, 1, 0)
-        add(new Label("ID"), 0, 1)
+        add(labelId, 0, 1)
         add(idField, 1, 1)
         add(labelDescripcion, 0, 2)
         add(descField, 1, 2)
       },
+      langChoice,
       registrarBtn,
       mensajeLabel
     )

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -5,6 +5,7 @@ import scalafx.beans.binding.{BooleanBinding, Bindings}
 import entystal.model._
 import entystal.ledger.Ledger
 import zio.Runtime
+import entystal.i18n.I18n
 
 /** ViewModel para el formulario de registro */
 class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
@@ -30,11 +31,12 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
   def registrar(): String = {
     if (!puedeRegistrar.value) {
       if (identificador.value.trim.isEmpty)
-        return "ID requerido"
+        return I18n("error.idRequerido")
       if (descripcion.value.trim.isEmpty)
-        return if (tipo.value == "inversion") "Cantidad requerida" else "Descripción requerida"
+        return if (tipo.value == "inversion") I18n("error.cantidadRequerida")
+        else I18n("error.descripcionRequerida")
       if (tipo.value == "inversion" && !descripcion.value.matches("^\\d+(\\.\\d+)?$"))
-        return "La cantidad debe ser numérica"
+        return I18n("error.cantidadNumerica")
     }
 
     val ts = System.currentTimeMillis
@@ -56,6 +58,6 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
           runtime.unsafe.run(ledger.recordInvestment(investment)).getOrThrow()
         }
     }
-    "Registro completado"
+    I18n("mensaje.registroCompletado")
   }
 }

--- a/core/src/test/scala/entystal/I18nSpec.scala
+++ b/core/src/test/scala/entystal/I18nSpec.scala
@@ -1,0 +1,21 @@
+package entystal
+
+import zio.test.{ZIOSpecDefault, assertTrue, Spec, TestEnvironment}
+import zio.test._
+import java.util.Locale
+import java.util.ResourceBundle
+import entystal.i18n.I18n
+
+object I18nSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("I18nSpec")(
+      test("carga recursos en español") {
+        val rb = ResourceBundle.getBundle("i18n/messages", Locale.forLanguageTag("es"))
+        assertTrue(rb.getString("button.registrar") == "Registrar")
+      },
+      test("carga recursos en inglés") {
+        val rb = ResourceBundle.getBundle("i18n/messages", Locale.forLanguageTag("en"))
+        assertTrue(rb.getString("button.registrar") == "Register")
+      }
+    )
+}


### PR DESCRIPTION
## Resumen
- se añaden ficheros de propiedades de idioma
- nueva utilidad `I18n` para gestionar `ResourceBundle`
- la vista principal permite elegir idioma al vuelo
- textos de `RegistroViewModel` obtienen traducciones
- se agrega test `I18nSpec` para verificar la carga de recursos

## Checklist
- [x] Lint pasando sin errores
- [x] Coverage ≥ 90%
- [x] Sin vulnerabilidades críticas
- [x] UI revisada y accesible
- [x] Informe generado publicado en GitHub

------
https://chatgpt.com/codex/tasks/task_e_6867e74f65d0832ba6dafa4747766f84