### PR TITLE
Añade selector de tema claro/oscuro

### DIFF
--- a/core/src/main/resources/css/dark-theme.css
+++ b/core/src/main/resources/css/dark-theme.css
@@ -1,0 +1,15 @@
+.root {
+  -fx-base: #2b2b2b;
+  -fx-background-color: #303030;
+  -fx-text-fill: #f0f0f0;
+}
+
+.button {
+  -fx-background-color: #2e7d32;
+  -fx-text-fill: #ffffff;
+}
+
+.text-field, .choice-box {
+  -fx-background-color: #424242;
+  -fx-text-fill: #f0f0f0;
+}

--- a/core/src/main/resources/css/light-theme.css
+++ b/core/src/main/resources/css/light-theme.css
@@ -1,0 +1,15 @@
+.root {
+  -fx-base: #ffffff;
+  -fx-background-color: #f4f4f4;
+  -fx-text-fill: #000000;
+}
+
+.button {
+  -fx-background-color: #4285f4;
+  -fx-text-fill: white;
+}
+
+.text-field, .choice-box {
+  -fx-background-color: white;
+  -fx-text-fill: #000000;
+}

--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -6,6 +6,7 @@ import entystal.{EntystalModule}
 import entystal.ledger.Ledger
 import entystal.viewmodel.RegistroViewModel
 import entystal.view.MainView
+import entystal.gui.ThemeManager
 import zio.Runtime
 
 /** Lanzador principal de la interfaz gráfica */
@@ -24,5 +25,7 @@ object GuiApp extends JFXApp3 {
       title = "Entystal GUI"
       scene = view.scene
     }
+    // Aplicar tema guardado al iniciar
+    ThemeManager.applyTheme(view.scene, ThemeManager.loadTheme())
   }
 }

--- a/core/src/main/scala/entystal/gui/ThemeManager.scala
+++ b/core/src/main/scala/entystal/gui/ThemeManager.scala
@@ -1,0 +1,35 @@
+package entystal.gui
+
+import scalafx.scene.Scene
+import scalafx.Includes._
+import java.util.prefs.Preferences
+
+/** Gestor de temas para la interfaz */
+object ThemeManager {
+  private val prefs    = Preferences.userRoot().node("/entystal/gui")
+  private val ThemeKey = "theme"
+
+  sealed trait Theme { def css: String }
+  case object Light extends Theme { val css = "/css/light-theme.css" }
+  case object Dark  extends Theme { val css = "/css/dark-theme.css"  }
+
+  /** Carga el tema almacenado o usa claro por defecto */
+  def loadTheme(): Theme =
+    prefs.get(ThemeKey, "light") match {
+      case "dark" => Dark
+      case _      => Light
+    }
+
+  /** Aplica y guarda el tema actual */
+  def applyTheme(scene: Scene, theme: Theme): Unit = {
+    scene.stylesheets.clear()
+    scene.stylesheets += theme.css
+    prefs.put(
+      ThemeKey,
+      theme match {
+        case Dark  => "dark"
+        case Light => "light"
+      }
+    )
+  }
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -1,12 +1,13 @@
 package entystal.view
 
 import scalafx.scene.Scene
-import scalafx.scene.control.{Button, ChoiceBox, Label, TextField}
+import scalafx.scene.control.{Button, ChoiceBox, Label, TextField, CheckBox}
 import scalafx.scene.layout.{GridPane, VBox}
 import scalafx.collections.ObservableBuffer
 import scalafx.Includes._
 import scalafx.geometry.Insets
 import entystal.viewmodel.RegistroViewModel
+import entystal.gui.ThemeManager
 
 /** Vista principal de registro */
 class MainView(vm: RegistroViewModel) {
@@ -29,6 +30,9 @@ class MainView(vm: RegistroViewModel) {
 
   private val mensajeLabel = new Label()
 
+  private val darkModeSwitch = new CheckBox("Tema oscuro")
+  darkModeSwitch.selected = ThemeManager.loadTheme() == ThemeManager.Dark
+
   private val registrarBtn = new Button("Registrar") {
     disable <== vm.puedeRegistrar.not()
     onAction = _ => mensajeLabel.text = vm.registrar()
@@ -36,6 +40,11 @@ class MainView(vm: RegistroViewModel) {
 
   tipoChoice.value.onChange { (_, _, nv) =>
     labelDescripcion.text = if (nv == "inversion") "Cantidad" else "Descripción"
+  }
+
+  darkModeSwitch.selected.onChange { (_, _, nv) =>
+    val theme = if (nv) ThemeManager.Dark else ThemeManager.Light
+    ThemeManager.applyTheme(scene, theme)
   }
 
   val rootPane = new VBox(10) {
@@ -52,11 +61,14 @@ class MainView(vm: RegistroViewModel) {
         add(descField, 1, 2)
       },
       registrarBtn,
+      darkModeSwitch,
       mensajeLabel
     )
   }
 
   val scene = new Scene(400, 200) {
     root = rootPane
+    // Cargar tema guardado al crear la vista
+    stylesheets += ThemeManager.loadTheme().css
   }
 }


### PR DESCRIPTION
## Resumen
- crea hojas de estilo `light-theme.css` y `dark-theme.css`
- implementa `ThemeManager` para guardar y aplicar la preferencia
- añade un switch en `MainView` para alternar el tema
- carga el tema guardado al iniciar `GuiApp`

## Testing
- `sbt scalafmtAll`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6867e750d468832ba5fb8bf67aa198bf