### PR TITLE
Implementación de Notifier y pruebas de Registro

### DIFF
--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -6,6 +6,7 @@ import entystal.{EntystalModule}
 import entystal.ledger.Ledger
 import entystal.viewmodel.RegistroViewModel
 import entystal.view.MainView
+import entystal.service.DialogNotifier
 import zio.Runtime
 
 /** Lanzador principal de la interfaz gráfica */
@@ -17,7 +18,7 @@ object GuiApp extends JFXApp3 {
         .run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get)))
         .getOrThrow()
     }
-    val vm                             = new RegistroViewModel(ledger)
+    val vm                             = new RegistroViewModel(ledger, DialogNotifier)
     val view                           = new MainView(vm)
 
     stage = new JFXApp3.PrimaryStage {

--- a/core/src/main/scala/entystal/service/Notifier.scala
+++ b/core/src/main/scala/entystal/service/Notifier.scala
@@ -1,0 +1,33 @@
+package entystal.service
+
+import scalafx.scene.control.Alert
+import scalafx.scene.control.Alert.AlertType
+
+/** Servicio para mostrar notificaciones modales. */
+trait Notifier {
+  def success(msg: String): Unit
+  def error(msg: String): Unit
+  def warning(msg: String): Unit
+}
+
+/** Implementación basada en cuadros de diálogo de ScalaFX. */
+object DialogNotifier extends Notifier {
+  override def success(msg: String): Unit =
+    show(AlertType.Information, "Éxito", msg)
+
+  override def error(msg: String): Unit =
+    show(AlertType.Error, "Error", msg)
+
+  override def warning(msg: String): Unit =
+    show(AlertType.Warning, "Advertencia", msg)
+
+  private def show(alertType: AlertType, titleStr: String, msg: String): Unit = {
+    val alert = new Alert(alertType) {
+      headerText = null: String
+      title = titleStr
+      contentText = msg
+    }
+    alert.showAndWait()
+    ()
+  }
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -27,11 +27,9 @@ class MainView(vm: RegistroViewModel) {
     promptText = "Descripción o cantidad"
   }
 
-  private val mensajeLabel = new Label()
-
   private val registrarBtn = new Button("Registrar") {
     disable <== vm.puedeRegistrar.not()
-    onAction = _ => mensajeLabel.text = vm.registrar()
+    onAction = _ => vm.registrar()
   }
 
   tipoChoice.value.onChange { (_, _, nv) =>
@@ -51,8 +49,7 @@ class MainView(vm: RegistroViewModel) {
         add(labelDescripcion, 0, 2)
         add(descField, 1, 2)
       },
-      registrarBtn,
-      mensajeLabel
+      registrarBtn
     )
   }
 

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -1,13 +1,16 @@
 package entystal.viewmodel
 
-import scalafx.beans.property.{StringProperty, ObjectProperty}
+import scalafx.beans.property.StringProperty
 import scalafx.beans.binding.{BooleanBinding, Bindings}
 import entystal.model._
 import entystal.ledger.Ledger
+import entystal.service.Notifier
 import zio.Runtime
 
 /** ViewModel para el formulario de registro */
-class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
+class RegistroViewModel(ledger: Ledger, notifier: Notifier)(implicit
+    runtime: Runtime[Any]
+) {
   val tipo          = StringProperty("activo")
   val identificador = StringProperty("")
   val descripcion   = StringProperty("")
@@ -26,15 +29,23 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
     tipo
   )
 
-  /** Devuelve mensaje de error o confirma el registro */
-  def registrar(): String = {
+  /** Ejecuta el registro mostrando el resultado mediante el notifier */
+  def registrar(): Unit = {
     if (!puedeRegistrar.value) {
-      if (identificador.value.trim.isEmpty)
-        return "ID requerido"
-      if (descripcion.value.trim.isEmpty)
-        return if (tipo.value == "inversion") "Cantidad requerida" else "Descripción requerida"
-      if (tipo.value == "inversion" && !descripcion.value.matches("^\\d+(\\.\\d+)?$"))
-        return "La cantidad debe ser numérica"
+      if (identificador.value.trim.isEmpty) {
+        notifier.error("ID requerido")
+        return
+      }
+      if (descripcion.value.trim.isEmpty) {
+        notifier.error(
+          if (tipo.value == "inversion") "Cantidad requerida" else "Descripción requerida"
+        )
+        return
+      }
+      if (tipo.value == "inversion" && !descripcion.value.matches("^\\d+(\\.\\d+)?$")) {
+        notifier.error("La cantidad debe ser numérica")
+        return
+      }
     }
 
     val ts = System.currentTimeMillis
@@ -56,6 +67,6 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
           runtime.unsafe.run(ledger.recordInvestment(investment)).getOrThrow()
         }
     }
-    "Registro completado"
+    notifier.success("Registro completado")
   }
 }

--- a/core/src/test/scala/entystal/service/TestNotifier.scala
+++ b/core/src/test/scala/entystal/service/TestNotifier.scala
@@ -1,0 +1,12 @@
+package entystal.service
+
+/** Implementación de Notifier que acumula las llamadas para pruebas. */
+class TestNotifier extends Notifier {
+  var last: Option[(String, String)]      = None
+  override def success(msg: String): Unit =
+    last = Some("success" -> msg)
+  override def error(msg: String): Unit   =
+    last = Some("error" -> msg)
+  override def warning(msg: String): Unit =
+    last = Some("warning" -> msg)
+}

--- a/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
+++ b/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
@@ -1,0 +1,46 @@
+package entystal.viewmodel
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.ledger.InMemoryLedger
+import entystal.service.TestNotifier
+import zio.{Runtime, ZIO}
+
+class RegistroViewModelSpec extends AnyFlatSpec with Matchers {
+  implicit val runtime: Runtime[Any] = Runtime.default
+
+  private def newVm(notifier: TestNotifier) = {
+    val ledger = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
+    }
+    new RegistroViewModel(ledger, notifier)
+  }
+
+  "RegistroViewModel" should "notificar error si falta ID" in {
+    val notifier = new TestNotifier
+    val vm       = newVm(notifier)
+    vm.descripcion.value = "d"
+    vm.registrar()
+    notifier.last shouldBe Some("error" -> "ID requerido")
+  }
+
+  it should "notificar error si la cantidad no es numérica" in {
+    val notifier = new TestNotifier
+    val vm       = newVm(notifier)
+    vm.tipo.value = "inversion"
+    vm.identificador.value = "inv1"
+    vm.descripcion.value = "abc"
+    vm.registrar()
+    notifier.last shouldBe Some("error" -> "La cantidad debe ser numérica")
+  }
+
+  it should "notificar éxito al registrar un activo" in {
+    val notifier = new TestNotifier
+    val vm       = newVm(notifier)
+    vm.tipo.value = "activo"
+    vm.identificador.value = "a1"
+    vm.descripcion.value = "desc"
+    vm.registrar()
+    notifier.last shouldBe Some("success" -> "Registro completado")
+  }
+}


### PR DESCRIPTION
## Resumen
- Servicio `Notifier` con diálogos modales mediante ScalaFX
- Integración del Notifier en `RegistroViewModel` y vistas
- Actualización de `GuiApp` para usar el nuevo servicio
- Pruebas unitarias del ViewModel con `TestNotifier`

## Checklist
- [x] Lint ejecutado (`scalafmt`)
- [x] Pruebas en verde (`sbt test`)
- [x] Sin vulnerabilidades críticas
- [ ] UI revisada y accesible (manual)
- [ ] Informe generado publicado en GitHub


------
https://chatgpt.com/codex/tasks/task_e_6867e751ebf8832b823255a784d62a0e