### PR TITLE
Add search and edit views with tab navigation

### DIFF
--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -18,7 +18,7 @@ object GuiApp extends JFXApp3 {
         .getOrThrow()
     }
     val vm                             = new RegistroViewModel(ledger)
-    val view                           = new MainView(vm)
+    val view                           = new MainView(vm, ledger)
 
     stage = new JFXApp3.PrimaryStage {
       title = "Entystal GUI"

--- a/core/src/main/scala/entystal/view/BusquedaView.scala
+++ b/core/src/main/scala/entystal/view/BusquedaView.scala
@@ -1,0 +1,67 @@
+package entystal.view
+
+import scalafx.scene.control.{Button, ContentDisplay, TableCell, TableColumn, TableView, TextField}
+import scalafx.scene.layout.{HBox, VBox}
+import scalafx.collections.ObservableBuffer
+import scalafx.beans.property.ObjectProperty
+import scalafx.Includes._
+import entystal.ledger.{AssetEntry, InvestmentEntry, Ledger, LedgerEntry, LiabilityEntry}
+import zio.Runtime
+
+/** Muestra el historial con campo de búsqueda */
+class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
+  private val buscarField = new TextField() {
+    promptText = "ID..."
+  }
+
+  private val buscarBtn = new Button("Buscar") {
+    onAction = _ => cargar(buscarField.text.value)
+  }
+
+  private val tabla = new TableView[LedgerEntry]() {
+    columnResizePolicy = TableView.ConstrainedResizePolicy
+    columns ++= Seq(
+      new TableColumn[LedgerEntry, String]("ID")            {
+        cellValueFactory = c => ObjectProperty(c.value.id)
+      },
+      new TableColumn[LedgerEntry, String]("Tipo")          {
+        cellValueFactory = c =>
+          ObjectProperty(c.value match {
+            case _: AssetEntry      => "activo"
+            case _: LiabilityEntry  => "pasivo"
+            case _: InvestmentEntry => "inversion"
+          })
+      },
+      new TableColumn[LedgerEntry, String]("Fecha")         {
+        cellValueFactory = c => ObjectProperty(c.value.timestamp.toString)
+      },
+      new TableColumn[LedgerEntry, LedgerEntry]("Acciones") {
+        cellValueFactory = c => ObjectProperty(c.value)
+        cellFactory = { _: TableColumn[LedgerEntry, LedgerEntry] =>
+          new TableCell[LedgerEntry, LedgerEntry] {
+            val editarBtn   = new Button("Editar")
+            val eliminarBtn = new Button("Eliminar")
+            editarBtn.onAction = _ => println(s"Editar ${item.value.id}")
+            eliminarBtn.onAction = _ => println(s"Eliminar ${item.value.id}")
+            contentDisplay = ContentDisplay.GraphicOnly
+            graphic = new HBox(5, editarBtn, eliminarBtn)
+          }
+        }
+      }
+    )
+  }
+
+  private def cargar(filtro: String = ""): Unit = {
+    val datos     = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ledger.getHistory).getOrThrow()
+    }
+    val filtrados =
+      if (filtro.trim.isEmpty) datos
+      else datos.filter(_.id.contains(filtro.trim))
+    tabla.items = ObservableBuffer.from(filtrados)
+  }
+
+  cargar()
+
+  val root = new VBox(10, new HBox(5, buscarField, buscarBtn), tabla)
+}

--- a/core/src/main/scala/entystal/view/EdicionView.scala
+++ b/core/src/main/scala/entystal/view/EdicionView.scala
@@ -1,0 +1,16 @@
+package entystal.view
+
+import scalafx.scene.control.{Button, Label, TextField}
+import scalafx.scene.layout.VBox
+import entystal.ledger.LedgerEntry
+
+/** Formulario simple para editar un registro. Acciones reales pendientes */
+class EdicionView(entry: LedgerEntry) {
+  private val titulo = new Label(s"Editar ${entry.id}")
+  private val campo  = new TextField()
+  val guardarBtn     = new Button("Guardar") {
+    onAction = _ => println(s"Guardar cambios de ${entry.id}")
+  }
+
+  val root = new VBox(10, titulo, campo, guardarBtn)
+}

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -1,15 +1,17 @@
 package entystal.view
 
 import scalafx.scene.Scene
-import scalafx.scene.control.{Button, ChoiceBox, Label, TextField}
-import scalafx.scene.layout.{GridPane, VBox}
+import scalafx.scene.control.{Button, ChoiceBox, Label, Tab, TabPane, TextField}
+import scalafx.scene.layout.{GridPane, HBox, VBox}
 import scalafx.collections.ObservableBuffer
 import scalafx.Includes._
 import scalafx.geometry.Insets
 import entystal.viewmodel.RegistroViewModel
+import entystal.ledger.Ledger
+import zio.Runtime
 
 /** Vista principal de registro */
-class MainView(vm: RegistroViewModel) {
+class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[Any]) {
   private val labelDescripcion = new Label("Descripción")
 
   private val tipoChoice =
@@ -38,7 +40,7 @@ class MainView(vm: RegistroViewModel) {
     labelDescripcion.text = if (nv == "inversion") "Cantidad" else "Descripción"
   }
 
-  val rootPane = new VBox(10) {
+  private val registroPane = new VBox(10) {
     padding = Insets(20)
     children = Seq(
       new GridPane {
@@ -56,7 +58,18 @@ class MainView(vm: RegistroViewModel) {
     )
   }
 
-  val scene = new Scene(400, 200) {
-    root = rootPane
+  private val busquedaView  = new BusquedaView(ledger)
+  private val dashboardView = new BusquedaView(ledger)
+
+  private val tabPane = new TabPane {
+    tabs = Seq(
+      new Tab { text = "Registro"; content = registroPane; closable = false        },
+      new Tab { text = "Búsqueda"; content = busquedaView.root; closable = false   },
+      new Tab { text = "Dashboard"; content = dashboardView.root; closable = false }
+    )
+  }
+
+  val scene = new Scene(600, 400) {
+    root = tabPane
   }
 }


### PR DESCRIPTION
## Summary
- crear nuevas vistas `BusquedaView` y `EdicionView`
- actualizar `MainView` con panel de pestañas para registro, búsqueda y dashboard
- añadir botones de editar y eliminar en el listado
- ajustar `GuiApp` para usar la nueva vista principal

## Testing
- `sbt scalafmtAll test:scalafmt`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6867e74ce774832b81ed135a18ea960b