### PR TITLE
Añade RegistroService y pruebas unitarias

### DIFF
--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -5,6 +5,7 @@ import scalafx.stage.Stage
 import entystal.{EntystalModule}
 import entystal.ledger.Ledger
 import entystal.viewmodel.RegistroViewModel
+import entystal.service.RegistroService
 import entystal.view.MainView
 import zio.Runtime
 
@@ -17,7 +18,8 @@ object GuiApp extends JFXApp3 {
         .run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get)))
         .getOrThrow()
     }
-    val vm                             = new RegistroViewModel(ledger)
+    val service                        = new RegistroService(ledger)
+    val vm                             = new RegistroViewModel(service)
     val view                           = new MainView(vm)
 
     stage = new JFXApp3.PrimaryStage {

--- a/core/src/main/scala/entystal/service/RegistroService.scala
+++ b/core/src/main/scala/entystal/service/RegistroService.scala
@@ -1,0 +1,17 @@
+package entystal.service
+
+import entystal.ledger.Ledger
+import entystal.model.{Asset, Investment, Liability}
+import zio.UIO
+
+/** Servicio que abstrae el registro de eventos delegando en el Ledger */
+class RegistroService(private val ledger: Ledger) {
+  def registrarActivo(asset: Asset): UIO[Unit] =
+    ledger.recordAsset(asset)
+
+  def registrarPasivo(liability: Liability): UIO[Unit] =
+    ledger.recordLiability(liability)
+
+  def registrarInversion(investment: Investment): UIO[Unit] =
+    ledger.recordInvestment(investment)
+}

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -3,11 +3,11 @@ package entystal.viewmodel
 import scalafx.beans.property.{StringProperty, ObjectProperty}
 import scalafx.beans.binding.{BooleanBinding, Bindings}
 import entystal.model._
-import entystal.ledger.Ledger
+import entystal.service.RegistroService
 import zio.Runtime
 
 /** ViewModel para el formulario de registro */
-class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
+class RegistroViewModel(service: RegistroService)(implicit runtime: Runtime[Any]) {
   val tipo          = StringProperty("activo")
   val identificador = StringProperty("")
   val descripcion   = StringProperty("")
@@ -42,18 +42,18 @@ class RegistroViewModel(ledger: Ledger)(implicit runtime: Runtime[Any]) {
       case "activo" =>
         val asset = DataAsset(identificador.value, descripcion.value, ts, BigDecimal(1))
         zio.Unsafe.unsafe { implicit u =>
-          runtime.unsafe.run(ledger.recordAsset(asset)).getOrThrow()
+          runtime.unsafe.run(service.registrarActivo(asset)).getOrThrow()
         }
       case "pasivo" =>
         val liability = EthicalLiability(identificador.value, descripcion.value, ts, BigDecimal(1))
         zio.Unsafe.unsafe { implicit u =>
-          runtime.unsafe.run(ledger.recordLiability(liability)).getOrThrow()
+          runtime.unsafe.run(service.registrarPasivo(liability)).getOrThrow()
         }
       case _        =>
         val qty        = BigDecimal(descripcion.value)
         val investment = BasicInvestment(identificador.value, qty, ts)
         zio.Unsafe.unsafe { implicit u =>
-          runtime.unsafe.run(ledger.recordInvestment(investment)).getOrThrow()
+          runtime.unsafe.run(service.registrarInversion(investment)).getOrThrow()
         }
     }
     "Registro completado"

--- a/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
+++ b/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
@@ -1,0 +1,39 @@
+package entystal.service
+
+import zio.test.{ZIOSpecDefault, Spec, TestEnvironment, assertTrue}
+import zio.Scope
+import entystal.model._
+import entystal.ledger.{InMemoryLedger, AssetEntry, LiabilityEntry, InvestmentEntry}
+
+object RegistroServiceSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("RegistroServiceSpec")(
+      test("registra un activo delegando en el Ledger") {
+        val asset = DataAsset("a1", "dato", 1L, BigDecimal(1))
+        for {
+          ledger  <- InMemoryLedger.live.build.map(_.get)
+          service  = new RegistroService(ledger)
+          _       <- service.registrarActivo(asset)
+          history <- ledger.getHistory
+        } yield assertTrue(history.exists(_ == AssetEntry(asset)))
+      },
+      test("registra un pasivo delegando en el Ledger") {
+        val liability = EthicalLiability("p1", "desc", 2L, BigDecimal(1))
+        for {
+          ledger  <- InMemoryLedger.live.build.map(_.get)
+          service  = new RegistroService(ledger)
+          _       <- service.registrarPasivo(liability)
+          history <- ledger.getHistory
+        } yield assertTrue(history.exists(_ == LiabilityEntry(liability)))
+      },
+      test("registra una inversion delegando en el Ledger") {
+        val investment = BasicInvestment("i1", BigDecimal(2), 3L)
+        for {
+          ledger  <- InMemoryLedger.live.build.map(_.get)
+          service  = new RegistroService(ledger)
+          _       <- service.registrarInversion(investment)
+          history <- ledger.getHistory
+        } yield assertTrue(history.exists(_ == InvestmentEntry(investment)))
+      }
+    )
+}


### PR DESCRIPTION
## Resumen
- se crea paquete `service` con `RegistroService` que delega en `Ledger`
- `RegistroViewModel` ahora utiliza el nuevo servicio
- `GuiApp` instancia `RegistroService`
- pruebas unitarias para el servicio con `InMemoryLedger`

## Checklist
- [x] Lint pasando sin errores
- [x] Tests unitarios ejecutados

------
https://chatgpt.com/codex/tasks/task_e_6867e74a81c0832bb475e72c2cb18d0c