### PR TITLE
Agregar pruebas de GUI con TestFX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           apps: sbt
       - name: Instalar cliente PostgreSQL
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Instalar Xvfb
+        run: sudo apt-get install -y xvfb
       - name: Inicializar base de datos
         env:
           PGUSER: postgres
@@ -46,4 +48,4 @@ jobs:
           PGPASSWORD: password
         run: |
           sbt scalafmtCheckAll
-          sbt test
+          xvfb-run --auto-servernum sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -30,6 +30,8 @@ jobs:
           apps: sbt
       - name: Instalar cliente PostgreSQL
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Instalar Xvfb
+        run: sudo apt-get install -y xvfb
       - name: Inicializar base de datos
         env:
           PGUSER: postgres
@@ -42,4 +44,4 @@ jobs:
           PGPASSWORD: password
         run: |
           sbt scalafmtAll
-          sbt test
+          xvfb-run --auto-servernum sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,8 @@ lazy val core = (project in file("core"))
       "org.openjfx" % "javafx-web" % javafxVersion classifier "linux",
       "org.scalafx" %% "scalafx" % "21.0.0-R32",
       "org.scalafx" %% "scalafxml-core-sfx8" % "0.5",
-      "org.apache.pdfbox" % "pdfbox" % "2.0.30"
+      "org.apache.pdfbox" % "pdfbox" % "2.0.30",
+      "org.testfx" % "testfx-junit" % "4.0.18" % Test
       ),
     scalacOptions ++= Seq(
       "-deprecation",

--- a/core/src/test/scala/entystal/gui/MainViewSpec.scala
+++ b/core/src/test/scala/entystal/gui/MainViewSpec.scala
@@ -1,0 +1,44 @@
+package entystal.gui
+
+import org.testfx.framework.junit.ApplicationTest
+import javafx.stage.Stage
+import scala.jdk.CollectionConverters._
+import entystal.view.MainView
+import entystal.viewmodel.RegistroViewModel
+import entystal.ledger.InMemoryLedger
+import org.junit.Assert._
+import zio.{Runtime, ZIO}
+
+class MainViewSpec extends ApplicationTest {
+  implicit val runtime: Runtime[Any] = Runtime.default
+
+  override def start(stage: Stage): Unit = {
+    val ledger = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
+    }
+    val vm     = new RegistroViewModel(ledger)
+    val view   = new MainView(vm, ledger)
+    stage.setScene(view.scene)
+    stage.show()
+  }
+
+  @org.junit.Test
+  def botonDeshabilitadoSinDatos(): Unit = {
+    val boton = lookup("Registrar").queryButton()
+    assertTrue(boton.isDisable)
+  }
+
+  @org.junit.Test
+  def registrarActivo(): Unit = {
+    val fields                                  = lookup(".text-field").queryAll().asScala.toSeq
+    clickOn(fields.head).write("a1")
+    clickOn(fields(1)).write("desc")
+    val boton                                   = lookup("Registrar").queryButton()
+    assertFalse(boton.isDisable)
+    clickOn(boton)
+    val nodes                                   = lookup(".label").queryAll().asScala.toSeq
+    val labels: Seq[javafx.scene.control.Label] =
+      nodes.collect { case l: javafx.scene.control.Label => l }
+    assertTrue(labels.exists(_.getText == "Registro completado"))
+  }
+}

--- a/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
+++ b/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
@@ -3,44 +3,37 @@ package entystal.viewmodel
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import entystal.ledger.InMemoryLedger
-import entystal.service.TestNotifier
 import zio.{Runtime, ZIO}
 
 class RegistroViewModelSpec extends AnyFlatSpec with Matchers {
   implicit val runtime: Runtime[Any] = Runtime.default
 
-  private def newVm(notifier: TestNotifier) = {
+  private def newVm() = {
     val ledger = zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
     }
-    new RegistroViewModel(ledger, notifier)
+    new RegistroViewModel(ledger)
   }
 
-  "RegistroViewModel" should "notificar error si falta ID" in {
-    val notifier = new TestNotifier
-    val vm       = newVm(notifier)
+  "RegistroViewModel" should "devolver error si falta ID" in {
+    val vm = newVm()
     vm.descripcion.value = "d"
-    vm.registrar()
-    notifier.last shouldBe Some("error" -> "ID requerido")
+    vm.registrar() shouldBe "ID requerido"
   }
 
-  it should "notificar error si la cantidad no es numérica" in {
-    val notifier = new TestNotifier
-    val vm       = newVm(notifier)
+  it should "devolver error si la cantidad no es numérica" in {
+    val vm = newVm()
     vm.tipo.value = "inversion"
     vm.identificador.value = "inv1"
     vm.descripcion.value = "abc"
-    vm.registrar()
-    notifier.last shouldBe Some("error" -> "La cantidad debe ser numérica")
+    vm.registrar() shouldBe "La cantidad debe ser numérica"
   }
 
-  it should "notificar éxito al registrar un activo" in {
-    val notifier = new TestNotifier
-    val vm       = newVm(notifier)
+  it should "registrar un activo correctamente" in {
+    val vm = newVm()
     vm.tipo.value = "activo"
     vm.identificador.value = "a1"
     vm.descripcion.value = "desc"
-    vm.registrar()
-    notifier.last shouldBe Some("success" -> "Registro completado")
+    vm.registrar() shouldBe "Registro completado"
   }
 }


### PR DESCRIPTION
## Resumen
- se incluye TestFX para pruebas de interfaz
- se añaden casos de `MainViewSpec` para validar la ventana principal
- se actualizan los workflows para ejecutar tests en entorno Xvfb
- se adapta `RegistroViewModelSpec` a la lógica actual

## Notas
- las pruebas GUI usan `ApplicationTest` y abren la ventana de forma básica


------
https://chatgpt.com/codex/tasks/task_e_6867ebc042c0832bb094be7cade42241