### PR TITLE
Actualiza vistas y corrige compilación

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,19 @@ Antes de utilizar `SqlLedger` recuerda aplicar el script `core/sql/entystal_sche
 
 ## Pruebas de integración
 
-Las pruebas que usan `SqlLedger` necesitan las variables `PGUSER` y `PGPASSWORD` configuradas. Se ejecutan automáticamente con:
+Las pruebas que usan `SqlLedger` necesitan las variables de entorno `PGUSER` (usuario) y
+`PGPASSWORD` (contrase\u00f1a) para conectar con PostgreSQL. Define dichos valores antes de
+ejecutar las pruebas:
+```bash
+export PGUSER=tu_usuario
+export PGPASSWORD=tu_contrase\u00f1a
+```
+Despu\u00e9s lanza las pruebas con:
 ```bash
 sbt test
 ```
-Si la base de datos no está disponible en `localhost:5432` las pruebas se marcan como **ignoradas**.
+Si la base de datos no est\u00e1 disponible en `localhost:5432` las pruebas se marcan como
+**ignoradas**.
 
 ## Contribución
 

--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -4,23 +4,26 @@ import scalafx.application.JFXApp3
 import scalafx.stage.Stage
 import entystal.{EntystalModule}
 import entystal.ledger.Ledger
-import entystal.viewmodel.RegistroViewModel
-import entystal.service.RegistroService
+import entystal.viewmodel.{RegistroValidator, RegistroViewModel}
+import entystal.service.{RegistroService, DialogNotifier}
 import entystal.view.MainView
-import entystal.service.DialogNotifier
+import entystal.gui.ThemeManager
+import entystal.i18n.I18n
 import zio.Runtime
 
 /** Lanzador principal de la interfaz gráfica */
 object GuiApp extends JFXApp3 {
   override def start(): Unit = {
     implicit val runtime: Runtime[Any] = Runtime.default
-    val ledger: Ledger                 = zio.Unsafe.unsafe { implicit u =>
+    val ledger: Ledger = zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe
         .run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get)))
         .getOrThrow()
     }
-    val vm                             = new RegistroViewModel(ledger)
-    val view                           = new MainView(vm, ledger)
+    val service    = new RegistroService(ledger)
+    val validator  = new RegistroValidator
+    val vm         = new RegistroViewModel(service, validator, DialogNotifier)
+    val view       = new MainView(vm, ledger)
 
     stage = new JFXApp3.PrimaryStage {
       title = I18n("app.title")

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -3,13 +3,16 @@ package entystal.viewmodel
 import scalafx.beans.property.StringProperty
 import scalafx.beans.binding.{BooleanBinding, Bindings}
 import entystal.model._
-import entystal.service.RegistroService
+import entystal.service.{RegistroService, Notifier}
 import zio.Runtime
 import entystal.i18n.I18n
 
 /** ViewModel para el formulario de registro */
-class RegistroViewModel(service: RegistroService)(implicit runtime: Runtime[Any]) {
-
+class RegistroViewModel(
+    service: RegistroService,
+    validator: RegistroValidator,
+    notifier: Notifier
+)(implicit runtime: Runtime[Any]) {
   val tipo          = StringProperty("activo")
   val identificador = StringProperty("")
   val descripcion   = StringProperty("")

--- a/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
+++ b/core/src/test/scala/entystal/viewmodel/RegistroViewModelSpec.scala
@@ -3,7 +3,8 @@ package entystal.viewmodel
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import entystal.ledger.InMemoryLedger
-import entystal.service.TestNotifier
+import entystal.service.{TestNotifier, RegistroService}
+import entystal.viewmodel.RegistroValidator
 import zio.{Runtime, ZIO}
 
 class RegistroViewModelSpec extends AnyFlatSpec with Matchers {
@@ -13,7 +14,9 @@ class RegistroViewModelSpec extends AnyFlatSpec with Matchers {
     val ledger = zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
     }
-    new RegistroViewModel(ledger, notifier)
+    val service   = new RegistroService(ledger)
+    val validator = new RegistroValidator
+    new RegistroViewModel(service, validator, notifier)
   }
 
   "RegistroViewModel" should "notificar error si falta ID" in {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9


### PR DESCRIPTION
## Resumen
- se define RegistroViewModel con validator y notifier
- se actualiza MainView incorporando i18n y modo oscuro
- GuiApp crea validator, servicio y vm adecuados
- se añaden instrucciones para PGUSER y PGPASSWORD en README

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6867ebc1603c832b9f7263ec07b56457