### PR TITLE
Arreglar GuiAppSpec con TestFX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
           PGPASSWORD: password
         run: |
           sbt scalafmtCheckAll
-          sbt test
+          sbt -Dtestfx.headless=true test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -42,4 +42,4 @@ jobs:
           PGPASSWORD: password
         run: |
           sbt scalafmtAll
-          sbt test
+          sbt -Dtestfx.headless=true test

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,12 @@ lazy val core = (project in file("core"))
       "org.openjfx" % "javafx-swing" % javafxVersion classifier "linux",
       "org.openjfx" % "javafx-web" % javafxVersion classifier "linux",
       "org.scalafx" %% "scalafx" % "21.0.0-R32",
-      "org.scalafx" %% "scalafxml-core-sfx8" % "0.5"
+      "org.scalafx" %% "scalafxml-core-sfx8" % "0.5",
+      "org.testfx" % "testfx-core" % "4.0.15-alpha" % Test,
+      "org.testfx" % "testfx-junit" % "4.0.15-alpha" % Test,
+      "org.testfx" % "openjfx-monocle" % "21.0.2" % Test,
+      "junit" % "junit" % "4.13.2" % Test,
+      "com.novocode" % "junit-interface" % "0.11" % Test
       ),
     scalacOptions ++= Seq(
       "-deprecation",
@@ -46,6 +51,15 @@ lazy val core = (project in file("core"))
     ),
       Test / fork := true,
       Test / parallelExecution := false,
+      Test / javaOptions ++= Seq(
+        "-Dtestfx.robot=glass",
+        "-Dtestfx.headless=true",
+        "-Dglass.platform=Monocle",
+        "-Dmonocle.platform=Headless",
+        "-Dprism.order=sw",
+        "-Dprism.text=t2k",
+        "-Djava.awt.headless=true"
+      ),
       assembly / assemblyMergeStrategy := {
         case PathList("META-INF", _ @ _*) => MergeStrategy.discard
         case "module-info.class"         => MergeStrategy.discard

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -10,28 +10,34 @@ import entystal.viewmodel.RegistroViewModel
 
 /** Vista principal de registro */
 class MainView(vm: RegistroViewModel) {
-  private val labelDescripcion = new Label("Descripción")
+  val labelDescripcion = new Label("Descripción")
 
-  private val tipoChoice =
+  val tipoChoice =
     new ChoiceBox[String](ObservableBuffer("activo", "pasivo", "inversion")) {
       value <==> vm.tipo
+      id = "tipoChoice"
     }
 
-  private val idField = new TextField() {
+  val idField = new TextField() {
     text <==> vm.identificador
     promptText = "ID"
+    id = "idField"
   }
 
-  private val descField = new TextField() {
+  val descField = new TextField() {
     text <==> vm.descripcion
     promptText = "Descripción o cantidad"
+    id = "descField"
   }
 
-  private val mensajeLabel = new Label()
+  val mensajeLabel = new Label() {
+    id = "mensajeLabel"
+  }
 
-  private val registrarBtn = new Button("Registrar") {
+  val registrarBtn = new Button("Registrar") {
     disable <== vm.puedeRegistrar.not()
     onAction = _ => mensajeLabel.text = vm.registrar()
+    id = "registrarBtn"
   }
 
   tipoChoice.value.onChange { (_, _, nv) =>

--- a/core/src/test/scala/entystal/gui/GuiAppSpec.scala
+++ b/core/src/test/scala/entystal/gui/GuiAppSpec.scala
@@ -1,0 +1,41 @@
+package entystal.gui
+
+import javafx.stage.Stage
+import javafx.scene.control.{Button, Label}
+import org.junit.Test
+import org.testfx.framework.junit.ApplicationTest
+import org.scalatest.matchers.should.Matchers
+import entystal.ledger.AssetEntry
+import entystal.model.DataAsset
+import zio.Runtime
+
+/** Pruebas de interfaz con TestFX */
+class GuiAppSpec extends ApplicationTest with Matchers {
+  private implicit val runtime: Runtime[Any] = Runtime.default
+
+  override def start(stage: Stage): Unit = {
+    new GuiAppTestApp().start(stage)
+  }
+
+  @Test def botonDeshabilitadoAlInicio(): Unit = {
+    val btn = lookup("#registrarBtn").queryAs(classOf[Button])
+    btn.isDisable shouldBe true
+  }
+
+  @Test def registrarActivo(): Unit = {
+    clickOn("#idField").write("a1")
+    clickOn("#descField").write("dato gui")
+    clickOn("#registrarBtn")
+
+    val label = lookup("#mensajeLabel").queryAs(classOf[Label])
+    label.getText shouldBe "Registro completado"
+
+    val history = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(GuiApp.appLedger.getHistory).getOrThrow()
+    }
+    history.exists {
+      case AssetEntry(a: DataAsset) => a.id == "a1" && a.data == "dato gui"
+      case _                        => false
+    } shouldBe true
+  }
+}

--- a/core/src/test/scala/entystal/gui/GuiAppTestApp.scala
+++ b/core/src/test/scala/entystal/gui/GuiAppTestApp.scala
@@ -1,37 +1,30 @@
 package entystal.gui
 
+import javafx.application.Application
+import javafx.stage.Stage
 import scalafx.application.JFXApp3
-import scalafx.stage.Stage
 import entystal.{EntystalModule}
 import entystal.ledger.Ledger
 import entystal.viewmodel.RegistroViewModel
 import entystal.view.MainView
 import zio.Runtime
 
-/** Lanzador principal de la interfaz gráfica */
-object GuiApp extends JFXApp3 {
-
-  /** Ledger utilizado por la aplicación, visible para pruebas */
-  private[gui] var appLedger: Ledger = _
-
-  /** ViewModel utilizado por la aplicación, visible para pruebas */
-  private[gui] var appViewModel: RegistroViewModel = _
-
-  override def start(): Unit = {
+/** Lanzador de GuiApp compatible con TestFX */
+class GuiAppTestApp extends Application {
+  override def start(primaryStage: Stage): Unit = {
     implicit val runtime: Runtime[Any] = Runtime.default
     val ledger: Ledger                 = zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe
         .run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get)))
         .getOrThrow()
     }
-    appLedger = ledger
+    GuiApp.appLedger = ledger
     val vm                             = new RegistroViewModel(ledger)
-    appViewModel = vm
+    GuiApp.appViewModel = vm
     val view                           = new MainView(vm)
 
-    stage = new JFXApp3.PrimaryStage {
-      title = "Entystal GUI"
-      scene = view.scene
-    }
+    primaryStage.setScene(view.scene.delegate)
+    primaryStage.setTitle("Entystal GUI")
+    primaryStage.show()
   }
 }


### PR DESCRIPTION
## Resumen
- reescritura de la suite `GuiAppSpec` usando TestFX
- inicializador de pruebas `GuiAppTestApp` crea la vista sin `JFXApp3`

## Checklist
- [ ] Lint pasando sin errores
- [ ] Coverage ≥ 90%
- [ ] Sin vulnerabilidades críticas
- [ ] UI revisada y accesible
- [ ] Informe generado publicado en GitHub

------
https://chatgpt.com/codex/tasks/task_e_6867e7525104832bb98f74515c8f2179