### PR TITLE
Implementa métodos de exportación y registro

### DIFF
--- a/core/src/main/scala/entystal/service/RegistroService.scala
+++ b/core/src/main/scala/entystal/service/RegistroService.scala
@@ -1,11 +1,14 @@
 package entystal.service
 
-import entystal.ledger.Ledger
-import entystal.model.{Asset, Investment, Liability}
-import zio.UIO
+import entystal.ledger._
+import entystal.model._
+import entystal.viewmodel.RegistroData
+import entystal.util.{CsvExporter, PdfExporter}
+import zio.{Runtime, UIO}
 
 /** Servicio que abstrae el registro de eventos delegando en el Ledger */
 class RegistroService(private val ledger: Ledger) {
+  private val runtime                          = Runtime.default
   def registrarActivo(asset: Asset): UIO[Unit] =
     ledger.recordAsset(asset)
 
@@ -14,4 +17,58 @@ class RegistroService(private val ledger: Ledger) {
 
   def registrarInversion(investment: Investment): UIO[Unit] =
     ledger.recordInvestment(investment)
+
+  /** Crea el modelo correspondiente a partir de los datos y lo registra */
+  def registrar(data: RegistroData): UIO[Unit] =
+    data.tipo match {
+      case "activo"    =>
+        registrarActivo(
+          DataAsset(data.identificador, data.descripcion, System.currentTimeMillis(), BigDecimal(1))
+        )
+      case "pasivo"    =>
+        registrarPasivo(
+          BasicLiability(data.identificador, BigDecimal(1), System.currentTimeMillis())
+        )
+      case "inversion" =>
+        registrarInversion(
+          BasicInvestment(
+            data.identificador,
+            BigDecimal(data.descripcion),
+            System.currentTimeMillis()
+          )
+        )
+      case _           => zio.ZIO.unit
+    }
+
+  /** Suma los totales de activos, pasivos e inversiones */
+  def aggregateTotals(): UIO[(BigDecimal, BigDecimal, BigDecimal)] =
+    ledger.getHistory.map { history =>
+      history.foldLeft((BigDecimal(0), BigDecimal(0), BigDecimal(0))) {
+        case ((a, l, i), AssetEntry(asset))    => (a + asset.value, l, i)
+        case ((a, l, i), LiabilityEntry(liab)) => (a, l + liab.amount, i)
+        case ((a, l, i), InvestmentEntry(inv)) => (a, l, i + inv.quantity)
+      }
+    }
+
+  /** Exporta el historial completo a CSV y devuelve un mensaje de confirmación */
+  def exportCsv(path: String): String = {
+    val entries = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ledger.getHistory).getOrThrow()
+    }
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(CsvExporter.save(entries, path)).getOrThrow()
+    }
+    s"Historial CSV exportado a $path"
+  }
+
+  /** Exporta el historial completo a PDF y devuelve un mensaje de confirmación */
+  def exportPdf(path: String): String = {
+    val entries = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(ledger.getHistory).getOrThrow()
+    }
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(PdfExporter.save(entries, path)).getOrThrow()
+    }
+    s"Historial PDF exportado a $path"
+  }
 }

--- a/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroViewModel.scala
@@ -46,7 +46,10 @@ class RegistroViewModel(
     }
 
     val data = RegistroData(tipo.value, identificador.value, descripcion.value)
-    service.registrar(data)
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(service.registrar(data)).getOrThrow()
+    }
+    notifier.success("Registro completado")
   }
 
   /** Exporta el historial a CSV y devuelve mensaje de confirmación */

--- a/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
+++ b/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
@@ -2,8 +2,9 @@ package entystal.service
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import entystal.ledger.{InMemoryLedger, Ledger}
+import entystal.ledger.{InMemoryLedger, Ledger, AssetEntry, LiabilityEntry, InvestmentEntry}
 import entystal.model._
+import entystal.viewmodel.RegistroData
 
 class RegistroServiceSpec extends AnyFlatSpec with Matchers {
   "aggregateTotals" should "sumar correctamente" in {
@@ -15,18 +16,80 @@ class RegistroServiceSpec extends AnyFlatSpec with Matchers {
     }
     val service = new RegistroService(ledger)
     zio.Unsafe.unsafe { implicit u =>
-      runtime.unsafe.run {
-        for {
-          _ <- ledger.recordAsset(DataAsset("a1", "d", 1L, BigDecimal(10)))
-          _ <- ledger.recordLiability(BasicLiability("l1", BigDecimal(5), 2L))
-          _ <- ledger.recordInvestment(BasicInvestment("i1", BigDecimal(3), 3L))
-          t <- service.aggregateTotals()
-        } yield {
-          t._1 shouldBe BigDecimal(10)
-          t._2 shouldBe BigDecimal(5)
-          t._3 shouldBe BigDecimal(3)
+      runtime.unsafe
+        .run {
+          for {
+            _ <- ledger.recordAsset(DataAsset("a1", "d", 1L, BigDecimal(10)))
+            _ <- ledger.recordLiability(BasicLiability("l1", BigDecimal(5), 2L))
+            _ <- ledger.recordInvestment(BasicInvestment("i1", BigDecimal(3), 3L))
+            t <- service.aggregateTotals()
+          } yield {
+            t._1 shouldBe BigDecimal(10)
+            t._2 shouldBe BigDecimal(5)
+            t._3 shouldBe BigDecimal(3)
+          }
         }
-      }.getOrThrow()
+        .getOrThrow()
     }
+  }
+
+  "registrar" should "crear modelos segun tipo" in {
+    val runtime = zio.Runtime.default
+    val ledger  = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get)))
+        .getOrThrow()
+    }
+    val service = new RegistroService(ledger)
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run {
+          for {
+            _ <- service.registrar(RegistroData("activo", "a1", "desc"))
+            _ <- service.registrar(RegistroData("pasivo", "p1", ""))
+            _ <- service.registrar(RegistroData("inversion", "i1", "5"))
+            h <- ledger.getHistory
+          } yield {
+            h.collect { case AssetEntry(a) => a.id }.head shouldBe "a1"
+            h.collect { case LiabilityEntry(l) => l.id }.head shouldBe "p1"
+            h.collect { case InvestmentEntry(i) => i.id }.head shouldBe "i1"
+          }
+        }
+        .getOrThrow()
+    }
+  }
+
+  "exportCsv" should "generar archivos" in {
+    val runtime = zio.Runtime.default
+    val ledger  = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get)))
+        .getOrThrow()
+    }
+    val service = new RegistroService(ledger)
+    val tmpCsv  = java.nio.file.Files.createTempFile("reg", ".csv")
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(service.registrar(RegistroData("activo", "a1", "d"))).getOrThrow()
+    }
+    service.exportCsv(tmpCsv.toString)
+    assert(tmpCsv.toFile.exists())
+    tmpCsv.toFile.delete()
+  }
+
+  "exportPdf" should "generar archivos" in {
+    val runtime = zio.Runtime.default
+    val ledger  = zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe
+        .run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get)))
+        .getOrThrow()
+    }
+    val service = new RegistroService(ledger)
+    val tmpPdf  = java.nio.file.Files.createTempFile("reg", ".pdf")
+    zio.Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(service.registrar(RegistroData("pasivo", "p1", ""))).getOrThrow()
+    }
+    service.exportPdf(tmpPdf.toString)
+    assert(tmpPdf.toFile.exists())
+    tmpPdf.toFile.delete()
   }
 }


### PR DESCRIPTION
## Resumen
- añade la ejecución completa de registros y exportaciones en `RegistroService`
- actualiza `RegistroViewModel` para ejecutar el servicio y notificar éxito
- amplía las pruebas unitarias cubriendo registro y exportación

## Testing
- `sbt scalafmtAll`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_68696dc328c0832bb1f25e85ab475ae5