### PR TITLE
Añade método registrarPasivo y ajuste de nombre

### DIFF
--- a/core/src/main/scala/entystal/service/RegistroService.scala
+++ b/core/src/main/scala/entystal/service/RegistroService.scala
@@ -12,8 +12,11 @@ class RegistroService(private val ledger: Ledger) {
   def registrarActivo(asset: Asset): UIO[Unit] =
     ledger.recordAsset(asset)
 
+  def registrarPasivo(liability: Liability): UIO[Unit] =
+    ledger.recordLiability(liability)
+
   /** Registra un activo, pasivo o inversión y devuelve un mensaje de confirmación */
-  def registrar(data: RegistroData): String = {
+  def registrarSync(data: RegistroData): String = {
     val ts = System.currentTimeMillis()
     data.tipo match {
       case "activo" =>


### PR DESCRIPTION
## Resumen
- nuevo método `registrarPasivo` que delega en el ledger
- renombrado del registro sincrónico a `registrarSync`
- formateo con Scalafmt y pruebas verdes

## Checklist
- [x] Lint sin errores
- [x] Tests en verde
- [x] Sin vulnerabilidades críticas
- [ ] Informe de cobertura publicado en CI

------
https://chatgpt.com/codex/tasks/task_e_686976e8494c832bbd11d72e831f92b2