### PR TITLE
Añadir módulo REST y pruebas básicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ El código principal se encuentra en la carpeta `core/` y está organizado en m�
 - Interfaz de línea de comandos (CLI) para registrar eventos contables.
 - Interfaz gráfica (GUI) básica con ScalaFX para registrar activos, pasivos e inversiones.
 - Generación de JAR ejecutable mediante `sbt-assembly`.
+- Nuevo módulo `rest` con API HTTP para registrar eventos y consultar historial.
 
 ## Accesibilidad
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
 lazy val root = (project in file("."))
-  .aggregate(core)
+  .aggregate(core, rest)
   .settings(
     name := "entystal-root"
   )
@@ -66,3 +66,20 @@ lazy val core = (project in file("core"))
       coverageFailOnMinimum := false,
       coverageHighlighting := true
     )
+
+lazy val rest = (project in file("rest"))
+  .dependsOn(core)
+  .settings(
+    name := "entystal-rest",
+    libraryDependencies ++= Seq(
+      "org.http4s" %% "http4s-ember-server" % "0.23.23",
+      "org.http4s" %% "http4s-dsl" % "0.23.23",
+      "org.http4s" %% "http4s-circe" % "0.23.23",
+      "org.http4s" %% "http4s-ember-client" % "0.23.23" % Test,
+      "io.circe" %% "circe-generic" % "0.14.6",
+      "io.prometheus" % "simpleclient" % "0.16.0",
+      "io.prometheus" % "simpleclient_common" % "0.16.0",
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "dev.zio" %% "zio-json" % "0.6.2"
+    )
+  )

--- a/rest/src/main/scala/entystal/rest/Metrics.scala
+++ b/rest/src/main/scala/entystal/rest/Metrics.scala
@@ -1,0 +1,20 @@
+package entystal.rest
+
+import cats.effect.IO
+import io.prometheus.client.{CollectorRegistry, Counter}
+import io.prometheus.client.exporter.common.TextFormat
+import org.http4s.HttpRoutes
+import org.http4s.dsl.io._
+
+object Metrics {
+  private val requests: Counter =
+    Counter.build().name("rest_requests_total").help("Total de peticiones").register()
+
+  def record(): IO[Unit] = IO(requests.inc())
+
+  val routes: HttpRoutes[IO] = HttpRoutes.of[IO] { case GET -> Root / "metrics" =>
+    val writer = new java.io.StringWriter()
+    TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples())
+    Ok(writer.toString())
+  }
+}

--- a/rest/src/main/scala/entystal/rest/RestRoutes.scala
+++ b/rest/src/main/scala/entystal/rest/RestRoutes.scala
@@ -1,0 +1,62 @@
+package entystal.rest
+
+import cats.effect.IO
+import cats.syntax.all._
+import org.http4s.{EntityDecoder, EntityEncoder, HttpRoutes}
+import org.http4s.dsl.io._
+import org.http4s.circe._
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.generic.auto._
+import entystal.service.RegistroService
+import entystal.viewmodel.RegistroData
+import entystal.ledger._
+import zio.{Runtime, Unsafe}
+
+class RestRoutes(service: RegistroService)(implicit runtime: Runtime[Any]) {
+
+  implicit val registroDecoder: EntityDecoder[IO, RegistroData]        = jsonOf[IO, RegistroData]
+  implicit val ledgerEntryEncoder: Encoder[LedgerEntry]                = Encoder.instance {
+    case AssetEntry(a)      =>
+      Json.obj(
+        "id"        -> Json.fromString(a.id),
+        "timestamp" -> Json.fromLong(a.timestamp),
+        "tipo"      -> Json.fromString("activo")
+      )
+    case LiabilityEntry(l)  =>
+      Json.obj(
+        "id"        -> Json.fromString(l.id),
+        "timestamp" -> Json.fromLong(l.timestamp),
+        "tipo"      -> Json.fromString("pasivo")
+      )
+    case InvestmentEntry(i) =>
+      Json.obj(
+        "id"        -> Json.fromString(i.id),
+        "timestamp" -> Json.fromLong(i.timestamp),
+        "tipo"      -> Json.fromString("inversion")
+      )
+  }
+  implicit val ledgerListEncoder: EntityEncoder[IO, List[LedgerEntry]] =
+    jsonEncoderOf[IO, List[LedgerEntry]]
+
+  val routes: HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case req @ POST -> Root / "registro" =>
+      for {
+        data <- req.as[RegistroData]
+        _    <- IO.blocking(Unsafe.unsafe { implicit u =>
+                  runtime.unsafe.run(service.registrar(data)).getOrThrow()
+                })
+        _    <- Metrics.record()
+        resp <- Ok("ok")
+      } yield resp
+
+    case GET -> Root / "historial" =>
+      for {
+        hist <- IO.blocking(Unsafe.unsafe { implicit u =>
+                  runtime.unsafe.run(service.obtenerHistorial).getOrThrow()
+                })
+        _    <- Metrics.record()
+        resp <- Ok(hist.asJson)
+      } yield resp
+  }
+}

--- a/rest/src/main/scala/entystal/rest/RestServer.scala
+++ b/rest/src/main/scala/entystal/rest/RestServer.scala
@@ -1,0 +1,30 @@
+package entystal.rest
+
+import cats.effect.{IO, IOApp}
+import cats.syntax.semigroupk._
+import org.http4s.server.Router
+import org.http4s.ember.server.EmberServerBuilder
+import com.comcast.ip4s._
+import entystal.service.RegistroService
+import entystal.EntystalModule
+import zio.{Runtime, Unsafe}
+
+/** Servidor HTTP básico para registrar eventos y consultar historial */
+object RestServer extends IOApp.Simple {
+  override def run: IO[Unit] = {
+    implicit val runtime: Runtime[Any] = Runtime.default
+    val ledger                         = Unsafe.unsafe { implicit u =>
+      runtime.unsafe.run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get))).getOrThrow()
+    }
+    val service                        = new RegistroService(ledger)
+    val api                            = new RestRoutes(service).routes <+> Metrics.routes
+
+    EmberServerBuilder
+      .default[IO]
+      .withHost(host"0.0.0.0")
+      .withPort(port"8080")
+      .withHttpApp(Router("/" -> api).orNotFound)
+      .build
+      .useForever
+  }
+}

--- a/rest/src/test/scala/entystal/rest/RestRoutesSpec.scala
+++ b/rest/src/test/scala/entystal/rest/RestRoutesSpec.scala
@@ -1,0 +1,45 @@
+package entystal.rest
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.semigroupk._
+import org.http4s._
+import org.http4s.implicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import entystal.service.RegistroService
+import entystal.EntystalModule
+import entystal.viewmodel.RegistroData
+import entystal.ledger._
+import io.circe.generic.auto._
+import org.http4s.circe._
+import zio.{Runtime, Unsafe}
+
+class RestRoutesSpec extends AnyFlatSpec with Matchers {
+  implicit val runtime: Runtime[Any]                            = Runtime.default
+  implicit val registroEncoder: EntityEncoder[IO, RegistroData] = jsonEncoderOf[IO, RegistroData]
+
+  private val ledger  = Unsafe.unsafe { implicit u =>
+    runtime.unsafe.run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get))).getOrThrow()
+  }
+  private val service = new RegistroService(ledger)
+  private val app     = (new RestRoutes(service).routes <+> Metrics.routes).orNotFound
+
+  "POST /registro" should "guardar y consultar" in {
+    val req  =
+      Request[IO](Method.POST, uri"/registro").withEntity(RegistroData("activo", "a1", "desc"))
+    val resp = app.run(req).unsafeRunSync()
+    resp.status shouldBe Status.Ok
+
+    val histReq  = Request[IO](Method.GET, uri"/historial")
+    val histResp = app.run(histReq).unsafeRunSync()
+    val body     = histResp.as[String].unsafeRunSync()
+    body.contains("a1") shouldBe true
+  }
+
+  "GET /metrics" should "exponer metricas" in {
+    val req  = Request[IO](Method.GET, uri"/metrics")
+    val resp = app.run(req).unsafeRunSync()
+    resp.status shouldBe Status.Ok
+  }
+}


### PR DESCRIPTION
## Resumen
- nuevo subproyecto **rest** con http4s
- rutas `/registro`, `/historial` y `/metrics`
- servidor `RestServer` listo para ejecución
- método `obtenerHistorial` en `RegistroService`
- pruebas de integración para la API REST

## Checklist
- [x] Lint pasando
- [x] Pruebas unitarias y de integración
- [x] Cobertura agregada
- [x] Sin vulnerabilidades críticas
- [ ] Informe generado publicado en GitHub


------
https://chatgpt.com/codex/tasks/task_e_686976e9a29c832bac776aad6a407ed0