### PR TITLE
Implementa edición y eliminación en GUI

### DIFF
--- a/core/src/main/scala/entystal/ledger/SqlLedger.scala
+++ b/core/src/main/scala/entystal/ledger/SqlLedger.scala
@@ -83,6 +83,28 @@ class SqlLedger(xa: Transactor[Task]) extends Ledger {
 
     combined.transact(xa).orDie
   }
+
+  override def updateEntry(id: String, value: String): UIO[Unit] = {
+    val qAsset      = sql"UPDATE asset SET description = $value WHERE id = $id".update.run
+    val qLiability  = sql"UPDATE liability SET description = $value WHERE id = $id".update.run
+    val qInvestment = sql"UPDATE investment SET description = $value WHERE id = $id".update.run
+    (for {
+      _ <- qAsset
+      _ <- qLiability
+      _ <- qInvestment
+    } yield ()).transact(xa).orDie
+  }
+
+  override def deleteEntry(id: String): UIO[Unit] = {
+    val qAsset      = sql"DELETE FROM asset WHERE id = $id".update.run
+    val qLiability  = sql"DELETE FROM liability WHERE id = $id".update.run
+    val qInvestment = sql"DELETE FROM investment WHERE id = $id".update.run
+    (for {
+      _ <- qAsset
+      _ <- qLiability
+      _ <- qInvestment
+    } yield ()).transact(xa).orDie
+  }
 }
 
 object SqlLedger {

--- a/core/src/main/scala/entystal/view/EdicionView.scala
+++ b/core/src/main/scala/entystal/view/EdicionView.scala
@@ -2,15 +2,20 @@ package entystal.view
 
 import scalafx.scene.control.{Button, Label, TextField}
 import scalafx.scene.layout.VBox
-import entystal.ledger.LedgerEntry
+import entystal.ledger._
+import entystal.model.{DataAsset, EthicalLiability, BasicInvestment}
 
 /** Formulario simple para editar un registro. Acciones reales pendientes */
 class EdicionView(entry: LedgerEntry) {
-  private val titulo = new Label(s"Editar ${entry.id}")
-  private val campo  = new TextField()
-  val guardarBtn     = new Button("Guardar") {
-    onAction = _ => println(s"Guardar cambios de ${entry.id}")
+  private val titulo   = new Label(s"Editar ${entry.id}")
+  val campo: TextField = new TextField()
+  campo.text = entry match {
+    case AssetEntry(a: DataAsset)            => a.data
+    case LiabilityEntry(l: EthicalLiability) => l.description
+    case InvestmentEntry(i: BasicInvestment) => i.quantity.toString
+    case _                                   => ""
   }
+  val guardarBtn       = new Button("Guardar")
 
   val root = new VBox(10, titulo, campo, guardarBtn)
 }

--- a/core/src/test/scala/entystal/view/BusquedaViewSpec.scala
+++ b/core/src/test/scala/entystal/view/BusquedaViewSpec.scala
@@ -1,0 +1,28 @@
+package entystal.view
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalafx.application.Platform
+import entystal.ledger._
+import entystal.model._
+import zio.Runtime
+
+class BusquedaViewSpec extends AnyFlatSpec with Matchers {
+  "BusquedaView" should "refrescar la tabla tras eliminar" in {
+    try Platform.startup(() => {})
+    catch { case _: Exception => cancel("JavaFX no disponible") }
+    implicit val rt: Runtime[Any] = Runtime.default
+    val ledger: Ledger            = zio.Unsafe.unsafe { implicit u =>
+      rt.unsafe.run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
+    }
+    zio.Unsafe.unsafe { implicit u =>
+      rt.unsafe.run(ledger.recordAsset(DataAsset("a1", "d", 1L, BigDecimal(1)))).getOrThrow()
+    }
+    val view                      = new BusquedaView(ledger)
+    view.cargar()
+    view.tabla.items().size shouldBe 1
+    zio.Unsafe.unsafe { implicit u => rt.unsafe.run(ledger.deleteEntry("a1")).getOrThrow() }
+    view.cargar()
+    view.tabla.items().size shouldBe 0
+  }
+}


### PR DESCRIPTION
## Resumen
- añade métodos `updateEntry` y `deleteEntry` al `Ledger`
- implementa la lógica correspondiente en `SqlLedger` e `InMemoryLedger`
- expone acciones de edición y eliminación en `BusquedaView`
- mejora `EdicionView` para mostrar valores actuales
- agrega pruebas de servicio y prueba simple de GUI

## Testing
- `sbt scalafmtAll`
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_e_686976ec2228832ba4be03ee1d4e042c