### PR TITLE
Agregar botón para alternar tema

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Si generaste el JAR ensamblado también puedes ejecutarlo con:
 java -jar target/scala-2.13/entystal-core-assembly-*.jar
 ```
 
+#### Cambio de tema
+
+En la pestaña **Registro** hay un botón *Cambiar tema*. Al pulsarlo se alterna
+entre modo claro y oscuro y la aplicación recordará tu preferencia.
+
 Antes de utilizar `SqlLedger` recuerda aplicar el script `core/sql/entystal_schema.sql` en tu instancia de PostgreSQL.
 
 ## Pruebas de integración

--- a/core/src/main/resources/i18n/messages_en.properties
+++ b/core/src/main/resources/i18n/messages_en.properties
@@ -6,6 +6,7 @@ label.cantidad=Amount
 prompt.id=ID
 prompt.desc=Description or amount
 button.registrar=Register
+button.cambiarTema=Toggle theme
 mensaje.registroCompletado=Registration completed
 error.idRequerido=ID required
 error.descripcionRequerida=Description required

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -6,6 +6,7 @@ label.cantidad=Cantidad
 prompt.id=ID
 prompt.desc=Descripción o cantidad
 button.registrar=Registrar
+button.cambiarTema=Cambiar tema
 mensaje.registroCompletado=Registro completado
 error.idRequerido=ID requerido
 error.descripcionRequerida=Descripción requerida

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -6,6 +6,7 @@ label.cantidad=Montant
 prompt.id=ID
 prompt.desc=Description ou montant
 button.registrar=Enregistrer
+button.cambiarTema=Changer de thème
 mensaje.registroCompletado=Enregistrement terminé
 error.idRequerido=ID requis
 error.descripcionRequerida=Description requise

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -33,6 +33,9 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
     disable <== vm.puedeRegistrar.not()
     onAction = _ => vm.registrar()
   }
+  private val themeBtn         = new Button("Cambiar tema") {
+    onAction = _ => toggleTheme()
+  }
 
   tipoChoice.value.onChange { (_, _, _) => updateTexts() }
   langChoice.value.onChange { (_, _, nv) =>
@@ -48,10 +51,20 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
     idField.promptText = I18n("prompt.id")
     descField.promptText = I18n("prompt.desc")
     registrarBtn.text = I18n("button.registrar")
+    themeBtn.text = I18n("button.cambiarTema")
   }
 
   I18n.register(() => updateTexts())
   updateTexts()
+
+  private def toggleTheme(): Unit = {
+    val current = ThemeManager.loadTheme()
+    val next    = current match {
+      case ThemeManager.Light => ThemeManager.Dark
+      case ThemeManager.Dark  => ThemeManager.Light
+    }
+    ThemeManager.applyTheme(scene, next)
+  }
 
   private val registroPane = new VBox(10) {
     padding = Insets(20)
@@ -67,7 +80,8 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
         add(descField, 1, 2)
       },
       langChoice,
-      registrarBtn
+      registrarBtn,
+      themeBtn
     )
   }
 


### PR DESCRIPTION
## Resumen
- botón **Cambiar tema** en `MainView` para alternar entre modo claro y oscuro
- texto localizado en inglés, español y francés
- sección en README con indicaciones de uso

## Checklist
- [x] `sbt scalafmtAll`
- [x] `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_6869813dff18832bad0bd285176b9b55