### PR TITLE
Añadir tooltips y menu de ayuda

### DIFF
--- a/core/src/main/resources/i18n/messages_en.properties
+++ b/core/src/main/resources/i18n/messages_en.properties
@@ -11,3 +11,7 @@ error.idRequerido=ID required
 error.descripcionRequerida=Description required
 error.cantidadRequerida=Amount required
 error.cantidadNumerica=Amount must be numeric
+tooltip.registrar=Create a new record
+menu.ayuda=Help
+menu.acerca=About
+about.info=Register and query assets, liabilities and investments. See README and docs for details

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -11,3 +11,7 @@ error.idRequerido=ID requerido
 error.descripcionRequerida=Descripción requerida
 error.cantidadRequerida=Cantidad requerida
 error.cantidadNumerica=La cantidad debe ser numérica
+tooltip.registrar=Crear un nuevo registro
+menu.ayuda=Ayuda
+menu.acerca=Acerca de
+about.info=Registra y consulta activos, pasivos e inversiones. Revisa README y docs para más información

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -11,3 +11,7 @@ error.idRequerido=ID requis
 error.descripcionRequerida=Description requise
 error.cantidadRequerida=Montant requis
 error.cantidadNumerica=Le montant doit être numérique
+tooltip.registrar=Créer un nouvel enregistrement
+menu.ayuda=Aide
+menu.acerca=À propos
+about.info=Enregistrer et consulter actifs, passifs et investissements. Plus de détails dans README et le dossier docs

--- a/core/src/main/scala/entystal/i18n/I18n.scala
+++ b/core/src/main/scala/entystal/i18n/I18n.scala
@@ -5,7 +5,7 @@ import java.util.{Locale, ResourceBundle}
 
 /** Utilidad sencilla para manejar traducciones mediante ResourceBundle */
 object I18n {
-  val supportedLocales: Seq[Locale] = Seq(
+  val supportedLocales: Seq[Locale]  = Seq(
     Locale.forLanguageTag("es"),
     Locale.ENGLISH,
     Locale.FRENCH

--- a/core/src/main/scala/entystal/view/BusquedaView.scala
+++ b/core/src/main/scala/entystal/view/BusquedaView.scala
@@ -1,6 +1,14 @@
 package entystal.view
 
-import scalafx.scene.control.{Button, ContentDisplay, TableCell, TableColumn, TableView, TextField}
+import scalafx.scene.control.{
+  Button,
+  ContentDisplay,
+  TableCell,
+  TableColumn,
+  TableView,
+  TextField,
+  Tooltip
+}
 import scalafx.scene.layout.{HBox, VBox}
 import scalafx.stage.Stage
 import scalafx.scene.Scene
@@ -17,8 +25,10 @@ class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
     promptText = "ID..."
   }
 
-  private val buscarBtn = new Button("Buscar") {
+  private val buscarTooltip = new Tooltip("Buscar por ID")
+  private val buscarBtn     = new Button("Buscar") {
     onAction = _ => cargar(buscarField.text.value)
+    tooltip = buscarTooltip
   }
 
   val tabla = new TableView[LedgerEntry]() {
@@ -42,8 +52,12 @@ class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
         cellValueFactory = c => ObjectProperty(c.value)
         cellFactory = { _: TableColumn[LedgerEntry, LedgerEntry] =>
           new TableCell[LedgerEntry, LedgerEntry] {
-            val editarBtn   = new Button("Editar")
-            val eliminarBtn = new Button("Eliminar")
+            val editarTooltip   = new Tooltip("Editar registro")
+            val eliminarTooltip = new Tooltip("Eliminar registro")
+            val editarBtn       = new Button("Editar")
+            val eliminarBtn     = new Button("Eliminar")
+            editarBtn.tooltip = editarTooltip
+            eliminarBtn.tooltip = eliminarTooltip
             contentDisplay = ContentDisplay.GraphicOnly
             graphic = new HBox(5, editarBtn, eliminarBtn)
 

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -1,7 +1,19 @@
 package entystal.view
 
 import scalafx.scene.Scene
-import scalafx.scene.control.{Button, ChoiceBox, Label, Tab, TabPane, TextField}
+import scalafx.scene.control.{
+  Alert,
+  Button,
+  ChoiceBox,
+  Label,
+  Menu,
+  MenuBar,
+  MenuItem,
+  Tab,
+  TabPane,
+  TextField,
+  Tooltip
+}
 import scalafx.scene.layout.{GridPane, VBox}
 import scalafx.collections.ObservableBuffer
 import scalafx.Includes._
@@ -10,7 +22,6 @@ import entystal.viewmodel.RegistroViewModel
 import entystal.gui.ThemeManager
 import entystal.i18n.I18n
 import entystal.ledger.Ledger
-import entystal.i18n.I18n
 import zio.Runtime
 import java.util.Locale
 
@@ -29,10 +40,16 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
     }
   private val idField          = new TextField() { text <==> vm.identificador }
   private val descField        = new TextField() { text <==> vm.descripcion }
+  private val registrarTooltip = new Tooltip()
   private val registrarBtn     = new Button() {
     disable <== vm.puedeRegistrar.not()
     onAction = _ => vm.registrar()
+    tooltip = registrarTooltip
   }
+
+  private val acercaItem = new MenuItem() { onAction = _ => mostrarAcerca() }
+  private val ayudaMenu  = new Menu() { items = Seq(acercaItem) }
+  private val menuBar    = new MenuBar { menus = Seq(ayudaMenu) }
 
   tipoChoice.value.onChange { (_, _, _) => updateTexts() }
   langChoice.value.onChange { (_, _, nv) =>
@@ -48,6 +65,9 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
     idField.promptText = I18n("prompt.id")
     descField.promptText = I18n("prompt.desc")
     registrarBtn.text = I18n("button.registrar")
+    registrarTooltip.text = I18n("tooltip.registrar")
+    ayudaMenu.text = I18n("menu.ayuda")
+    acercaItem.text = I18n("menu.acerca")
   }
 
   I18n.register(() => updateTexts())
@@ -83,7 +103,15 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
   }
 
   val scene = new Scene(600, 400) {
-    root = tabPane
+    root = new VBox(menuBar, tabPane)
     stylesheets += ThemeManager.loadTheme().css
+  }
+
+  private def mostrarAcerca(): Unit = {
+    new Alert(Alert.AlertType.Information) {
+      title = I18n("menu.acerca")
+      headerText = "Entystal"
+      contentText = I18n("about.info")
+    }.showAndWait()
   }
 }


### PR DESCRIPTION
## Resumen
- agregar `Tooltip` a los botones principales
- crear menú **Ayuda > Acerca de** con alerta informativa
- actualizar mensajes de i18n

## Checklist
- [x] Lint pasando (`scalafmt`)
- [x] Pruebas ejecutadas (`sbt test`)


------
https://chatgpt.com/codex/tasks/task_e_686981408318832b9e462d2fa28d8434