### PR TITLE
Mejora de accesibilidad en vistas ScalaFX

### DIFF
--- a/core/src/main/scala/entystal/view/BusquedaView.scala
+++ b/core/src/main/scala/entystal/view/BusquedaView.scala
@@ -13,11 +13,14 @@ import zio.Runtime
 
 /** Muestra el historial con campo de búsqueda */
 class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
-  private val buscarField = new TextField() {
+  val buscarField = new TextField() {
     promptText = "ID..."
+    accessibleText = "Buscar por ID"
   }
 
-  private val buscarBtn = new Button("Buscar") {
+  val buscarBtn = new Button("_Buscar") {
+    mnemonicParsing = true
+    accessibleText = "Buscar"
     onAction = _ => cargar(buscarField.text.value)
   }
 
@@ -42,8 +45,14 @@ class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
         cellValueFactory = c => ObjectProperty(c.value)
         cellFactory = { _: TableColumn[LedgerEntry, LedgerEntry] =>
           new TableCell[LedgerEntry, LedgerEntry] {
-            val editarBtn   = new Button("Editar")
-            val eliminarBtn = new Button("Eliminar")
+            val editarBtn = new Button("_Editar") {
+              mnemonicParsing = true
+              accessibleText = "Editar registro"
+            }
+            val eliminarBtn = new Button("_Eliminar") {
+              mnemonicParsing = true
+              accessibleText = "Eliminar registro"
+            }
             contentDisplay = ContentDisplay.GraphicOnly
             graphic = new HBox(5, editarBtn, eliminarBtn)
 

--- a/core/src/main/scala/entystal/view/EdicionView.scala
+++ b/core/src/main/scala/entystal/view/EdicionView.scala
@@ -8,14 +8,19 @@ import entystal.model.{DataAsset, EthicalLiability, BasicInvestment}
 /** Formulario simple para editar un registro. Acciones reales pendientes */
 class EdicionView(entry: LedgerEntry) {
   private val titulo   = new Label(s"Editar ${entry.id}")
-  val campo: TextField = new TextField()
+  val campo: TextField = new TextField() {
+    accessibleText = "Campo de edición"
+  }
   campo.text = entry match {
     case AssetEntry(a: DataAsset)            => a.data
     case LiabilityEntry(l: EthicalLiability) => l.description
     case InvestmentEntry(i: BasicInvestment) => i.quantity.toString
     case _                                   => ""
   }
-  val guardarBtn       = new Button("Guardar")
+  val guardarBtn = new Button("_Guardar") {
+    mnemonicParsing = true
+    accessibleText = "Guardar cambios"
+  }
 
   val root = new VBox(10, titulo, campo, guardarBtn)
 }

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -27,10 +27,11 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
     new ChoiceBox[String](ObservableBuffer("activo", "pasivo", "inversion")) {
       value <==> vm.tipo
     }
-  private val idField          = new TextField() { text <==> vm.identificador }
-  private val descField        = new TextField() { text <==> vm.descripcion }
-  private val registrarBtn     = new Button() {
+  val idField   = new TextField() { text <==> vm.identificador }
+  val descField = new TextField() { text <==> vm.descripcion }
+  val registrarBtn = new Button() {
     disable <== vm.puedeRegistrar.not()
+    mnemonicParsing = true
     onAction = _ => vm.registrar()
   }
 
@@ -47,7 +48,12 @@ class MainView(vm: RegistroViewModel, ledger: Ledger)(implicit runtime: Runtime[
       else I18n("label.descripcion")
     idField.promptText = I18n("prompt.id")
     descField.promptText = I18n("prompt.desc")
-    registrarBtn.text = I18n("button.registrar")
+    idField.accessibleText = labelId.text.value
+    descField.accessibleText = labelDescripcion.text.value
+    tipoChoice.accessibleText = labelTipo.text.value
+    langChoice.accessibleText = "Idioma"
+    registrarBtn.text = "_" + I18n("button.registrar")
+    registrarBtn.accessibleText = I18n("button.registrar")
   }
 
   I18n.register(() => updateTexts())

--- a/core/src/test/scala/entystal/view/AccessibilitySpec.scala
+++ b/core/src/test/scala/entystal/view/AccessibilitySpec.scala
@@ -1,0 +1,37 @@
+package entystal.view
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalafx.application.Platform
+import entystal.service.{RegistroService, TestNotifier}
+import entystal.viewmodel.RegistroViewModel
+import entystal.ledger._
+import entystal.model._
+import zio.Runtime
+
+class AccessibilitySpec extends AnyFlatSpec with Matchers {
+  "Vistas" should "definir texto accesible y mnemonicos" in {
+    try Platform.startup(() => {})
+    catch { case _: Exception => cancel("JavaFX no disponible") }
+    implicit val rt: Runtime[Any] = Runtime.default
+    val ledger: Ledger            = zio.Unsafe.unsafe { implicit u =>
+      rt.unsafe.run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
+    }
+    val service  = new RegistroService(ledger)
+    val notifier = new TestNotifier
+    val vm       = new RegistroViewModel(service, notifier)
+
+    val mainView     = new MainView(vm, ledger)
+    mainView.registrarBtn.accessibleText.value shouldBe "Registrar"
+    mainView.registrarBtn.mnemonicParsing.value shouldBe true
+
+    val busquedaView = new BusquedaView(ledger)
+    busquedaView.buscarBtn.accessibleText.value shouldBe "Buscar"
+    busquedaView.buscarBtn.mnemonicParsing.value shouldBe true
+
+    val entry        = AssetEntry(DataAsset("a1", "d", 1L, BigDecimal(1)))
+    val edicionView  = new EdicionView(entry)
+    edicionView.guardarBtn.accessibleText.value shouldBe "Guardar cambios"
+    edicionView.guardarBtn.mnemonicParsing.value shouldBe true
+  }
+}


### PR DESCRIPTION
## Resumen
- asignación de `accessibleText` en campos y botones
- activación de `mnemonicParsing` con atajos de teclado
- pruebas unitarias que validan estos atributos

## Checklist
- [x] Lint pasando sin errores
- [x] Coverage ≥ 90%
- [x] Sin vulnerabilidades críticas
- [x] UI revisada y accesible
- [x] Informe generado publicado en GitHub

------
https://chatgpt.com/codex/tasks/task_e_6869813acd80832b9b338ea410a67eba