### PR TITLE
Actualiza secretos de PostgreSQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
+          POSTGRES_USER: ${{ secrets.PGUSER }}
+          POSTGRES_PASSWORD: ${{ secrets.PGPASSWORD }}
           POSTGRES_DB: entystal
         ports: ["5432:5432"]
         options: >-
@@ -40,20 +40,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Inicializar base de datos
         env:
-          PGUSER: postgres
-          PGPASSWORD: password
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: psql -h localhost -d entystal -f core/sql/entystal_schema.sql
       - name: Formateo y análisis estático
         env:
-          PGUSER: postgres
-          PGPASSWORD: password
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: |
           sbt scalafmtCheckAll > scalafmt.log
           sbt "scalafixAll --check" > scalafix.log
       - name: Pruebas y cobertura
         env:
-          PGUSER: postgres
-          PGPASSWORD: password
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: |
           sbt coverage test coverageReport
           sbt coverageAggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       postgres:
         image: postgres:15
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
+          POSTGRES_USER: ${{ secrets.PGUSER }}
+          POSTGRES_PASSWORD: ${{ secrets.PGPASSWORD }}
           POSTGRES_DB: entystal
         ports: ["5432:5432"]
         options: >-
@@ -34,8 +34,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Inicializar base de datos
         env:
-          PGUSER: postgres
-          PGPASSWORD: password
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: psql -h localhost -d entystal -f core/sql/entystal_schema.sql
       - name: Formateo y análisis estático
         run: |
@@ -43,8 +43,8 @@ jobs:
           sbt "scalafixAll --check"
       - name: Pruebas y cobertura
         env:
-          PGUSER: postgres
-          PGPASSWORD: password
+          PGUSER: ${{ secrets.PGUSER }}
+          PGPASSWORD: ${{ secrets.PGPASSWORD }}
         run: |
           sbt coverage test
           sbt coverageAggregate

--- a/README.md
+++ b/README.md
@@ -95,14 +95,7 @@ Antes de utilizar `SqlLedger` recuerda aplicar el script `core/sql/entystal_sche
 
 ## Pruebas de integración
 
-Las pruebas que usan `SqlLedger` necesitan las variables de entorno `PGUSER` (usuario) y
-`PGPASSWORD` (contrase\u00f1a) para conectar con PostgreSQL. Define dichos valores antes de
-ejecutar las pruebas:
-```bash
-export PGUSER=tu_usuario
-export PGPASSWORD=tu_contrase\u00f1a
-```
-Despu\u00e9s lanza las pruebas con:
+Las pruebas que usan `SqlLedger` requieren las variables de entorno `PGUSER` y `PGPASSWORD`. En los workflows de CI estas credenciales se configuran como **GitHub Secrets** y se inyectan de forma segura. Si ejecutas las pruebas localmente define esas variables en tu terminal o en un archivo `.env`.
 ```bash
 sbt test
 ```

--- a/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
+++ b/core/src/test/scala/entystal/ledger/SqlLedgerSpec.scala
@@ -9,36 +9,46 @@ import entystal.model._
 
 /** Pruebas de integración del SqlLedger usando PostgreSQL */
 object SqlLedgerSpec extends ZIOSpecDefault {
-  private val dbUser = sys.env.getOrElse("PGUSER", "postgres")
-  private val dbPass = sys.env.getOrElse("PGPASSWORD", "password")
+  private val dbUserOpt = sys.env.get("PGUSER")
+  private val dbPassOpt = sys.env.get("PGPASSWORD")
 
   private val dbUrl = "jdbc:postgresql://localhost:5432/entystal"
 
   /** Intento de conexión para saber si PostgreSQL está disponible */
   private val connectionCheck: Task[Boolean] =
-    ZIO
-      .attemptBlocking {
-        val conn = java.sql.DriverManager.getConnection(dbUrl, dbUser, dbPass)
-        try {
-          val st = conn.createStatement()
-          st.execute("SELECT 1")
-          true
-        } finally conn.close()
-      }
-      .tapError(e => ZIO.logError(s"No se pudo conectar a PostgreSQL: ${e.getMessage}"))
-      .orElseSucceed(false)
+    (dbUserOpt, dbPassOpt) match {
+      case (Some(user), Some(pass)) =>
+        ZIO
+          .attemptBlocking {
+            val conn = java.sql.DriverManager.getConnection(dbUrl, user, pass)
+            try {
+              val st = conn.createStatement()
+              st.execute("SELECT 1")
+              true
+            } finally conn.close()
+          }
+          .tapError(e => ZIO.logError(s"No se pudo conectar a PostgreSQL: ${e.getMessage}"))
+          .orElseSucceed(false)
+      case _ =>
+        ZIO.logWarning("Credenciales de PostgreSQL no definidas") *> ZIO.succeed(false)
+    }
 
   private val transactorLayer = ZLayer.scoped {
-    ZIO.attempt {
-      val props = new java.util.Properties()
-      props.setProperty("user", dbUser)
-      props.setProperty("password", dbPass)
-      Transactor.fromDriverManager[Task](
-        "org.postgresql.Driver",
-        dbUrl,
-        props,
-        None
-      )
+    (dbUserOpt, dbPassOpt) match {
+      case (Some(user), Some(pass)) =>
+        ZIO.attempt {
+          val props = new java.util.Properties()
+          props.setProperty("user", user)
+          props.setProperty("password", pass)
+          Transactor.fromDriverManager[Task](
+            "org.postgresql.Driver",
+            dbUrl,
+            props,
+            None
+          )
+        }
+      case _ =>
+        ZIO.fail(new Exception("Credenciales de PostgreSQL no definidas"))
     }
   }
 


### PR DESCRIPTION
## Resumen
- referencias a `secrets.PGUSER` y `secrets.PGPASSWORD` en los workflows
- documenta uso de secretos en README
- ajusta `SqlLedgerSpec` para leer credenciales desde el entorno

## Checklist
- [ ] Lint pasando sin errores
- [ ] Coverage ≥ 90%
- [ ] Sin vulnerabilidades críticas
- [ ] UI revisada y accesible
- [ ] Informe generado publicado en GitHub


------
https://chatgpt.com/codex/tasks/task_e_68698f16e410832b93feda233e78a60f