### PR TITLE
Implementa validación de entradas

### DIFF
--- a/core/src/main/scala/entystal/input_validation.scala
+++ b/core/src/main/scala/entystal/input_validation.scala
@@ -1,0 +1,28 @@
+package entystal
+
+/** Componente genérico de validación de entradas */
+trait InputValidator[T] {
+
+  /** Valida el valor indicado
+    * @return
+    *   Right(()) si es válido o Left(mensaje de error)
+    */
+  def validate(value: T): Either[String, Unit]
+}
+
+/** Validaciones disponibles */
+object InputValidators {
+  import entystal.viewmodel.RegistroData
+
+  /** Validador para los datos de registro */
+  object RegistroDataValidator extends InputValidator[RegistroData] {
+    def validate(data: RegistroData): Either[String, Unit] = {
+      if (data.identificador.trim.isEmpty) Left("ID requerido")
+      else if (data.descripcion.trim.isEmpty)
+        Left(if (data.tipo == "inversion") "Cantidad requerida" else "Descripción requerida")
+      else if (data.tipo == "inversion" && !data.descripcion.matches("^\\d+(\\.\\d+)?$"))
+        Left("La cantidad debe ser numérica")
+      else Right(())
+    }
+  }
+}

--- a/core/src/main/scala/entystal/viewmodel/RegistroValidator.scala
+++ b/core/src/main/scala/entystal/viewmodel/RegistroValidator.scala
@@ -1,21 +1,14 @@
 package entystal.viewmodel
 
+import entystal.InputValidator
+
 /** Datos introducidos en el formulario de registro */
 final case class RegistroData(tipo: String, identificador: String, descripcion: String)
 
 /** Encapsula la l\u00f3gica de validaci\u00f3n para el registro */
-class RegistroValidator {
+class RegistroValidator extends InputValidator[RegistroData] {
 
-  /** Valida el conjunto de datos.
-    * @return
-    *   Right(()) si es correcto o Left(mensaje de error)
-    */
-  def validate(data: RegistroData): Either[String, Unit] = {
-    if (data.identificador.trim.isEmpty) Left("ID requerido")
-    else if (data.descripcion.trim.isEmpty)
-      Left(if (data.tipo == "inversion") "Cantidad requerida" else "Descripci\u00f3n requerida")
-    else if (data.tipo == "inversion" && !data.descripcion.matches("^\\d+(\\.\\d+)?$"))
-      Left("La cantidad debe ser num\u00e9rica")
-    else Right(())
-  }
+  /** Delegamos en el validador compartido */
+  def validate(data: RegistroData): Either[String, Unit] =
+    entystal.InputValidators.RegistroDataValidator.validate(data)
 }


### PR DESCRIPTION
## Resumen
- se añade `InputValidator` y `RegistroDataValidator`
- `RestRoutes` y CLI usan la validación antes de registrar
- `RegistroValidator` delega en el nuevo componente

## Testing
- `sbt scalafmtAll`
- `sbt test` *(falla: no compila por clases JavaFX ausentes)*

------
https://chatgpt.com/codex/tasks/task_e_68698f198414832bab4083d683f47156