### PR TITLE
Agrega verificación de rutas en exportadores

### DIFF
--- a/core/src/main/scala/entystal/gui/GuiApp.scala
+++ b/core/src/main/scala/entystal/gui/GuiApp.scala
@@ -26,7 +26,7 @@ object GuiApp extends JFXApp3 {
     val statusLabel                    = new scalafx.scene.control.Label()
     val notifier                       = new StatusNotifier(statusLabel)
     val vm                             = new RegistroViewModel(service, notifier, validator)
-    val view                           = new MainView(vm, ledger, statusLabel, notifier)
+    val view                           = new MainView(vm, ledger, statusLabel)
 
     stage = new JFXApp3.PrimaryStage {
       title = I18n("app.title")

--- a/core/src/main/scala/entystal/util/CsvExporter.scala
+++ b/core/src/main/scala/entystal/util/CsvExporter.scala
@@ -5,10 +5,29 @@ import entystal.model._
 import zio.{Task, ZIO}
 
 /** Utilidad para exportar el historial del ledger a un fichero CSV */
+import java.nio.file.{Files, Path, Paths}
+
+/** Utilidad para exportar el historial del ledger a un fichero CSV */
 object CsvExporter {
+
+  /** Directorio permitido para las exportaciones */
+  val baseDir: Path = {
+    val dir = Paths.get("target", "exports").toAbsolutePath.normalize
+    Files.createDirectories(dir)
+    dir
+  }
+
+  private def validatePath(path: String): Path = {
+    val p = Paths.get(path).toAbsolutePath.normalize
+    if (!p.startsWith(baseDir))
+      throw new IllegalArgumentException(s"Ruta fuera de directorio permitido: $path")
+    p
+  }
+
   def save(entries: List[LedgerEntry], path: String): Task[Unit] =
     ZIO.attempt {
-      val writer = new java.io.PrintWriter(new java.io.File(path))
+      val valid  = validatePath(path)
+      val writer = new java.io.PrintWriter(valid.toFile)
       try {
         writer.println("type,id,description,timestamp")
         entries.foreach {

--- a/core/src/main/scala/entystal/util/PdfExporter.scala
+++ b/core/src/main/scala/entystal/util/PdfExporter.scala
@@ -7,11 +7,28 @@ import org.apache.pdfbox.pdmodel.{PDDocument, PDPage}
 import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.font.PDType1Font
 import org.apache.pdfbox.pdmodel.PDPageContentStream
+import java.nio.file.{Files, Path, Paths}
 
 /** Utilidad para exportar el historial del ledger a un PDF sencillo */
 object PdfExporter {
+
+  /** Directorio permitido para las exportaciones */
+  val baseDir: Path = {
+    val dir = Paths.get("target", "exports").toAbsolutePath.normalize
+    Files.createDirectories(dir)
+    dir
+  }
+
+  private def validatePath(path: String): Path = {
+    val p = Paths.get(path).toAbsolutePath.normalize
+    if (!p.startsWith(baseDir))
+      throw new IllegalArgumentException(s"Ruta fuera de directorio permitido: $path")
+    p
+  }
+
   def save(entries: List[LedgerEntry], path: String): Task[Unit] =
     ZIO.attempt {
+      val valid  = validatePath(path)
       val doc    = new PDDocument()
       val page   = new PDPage(PDRectangle.LETTER)
       doc.addPage(page)
@@ -32,7 +49,7 @@ object PdfExporter {
         stream.endText()
       } finally {
         stream.close()
-        doc.save(path)
+        doc.save(valid.toString)
         doc.close()
       }
     }

--- a/core/src/main/scala/entystal/view/BusquedaView.scala
+++ b/core/src/main/scala/entystal/view/BusquedaView.scala
@@ -26,7 +26,9 @@ class BusquedaView(ledger: Ledger)(implicit runtime: Runtime[Any]) {
     promptText = s"${I18n("prompt.id")}" + "..."
   }
 
-  private val buscarBtn = new Button(I18n("button.buscar")) {
+  private val buscarTooltip = new Tooltip()
+
+  val buscarBtn = new Button(I18n("button.buscar")) {
     onAction = _ => cargar(buscarField.text.value)
     tooltip = buscarTooltip
   }

--- a/core/src/main/scala/entystal/view/EdicionView.scala
+++ b/core/src/main/scala/entystal/view/EdicionView.scala
@@ -17,5 +17,5 @@ class EdicionView(entry: LedgerEntry) {
     case _                                   => ""
   }
   val guardarBtn       = new Button(I18n("button.guardar"))
-  val root = new VBox(10, titulo, campo, guardarBtn)
+  val root             = new VBox(10, titulo, campo, guardarBtn)
 }

--- a/core/src/main/scala/entystal/view/MainView.scala
+++ b/core/src/main/scala/entystal/view/MainView.scala
@@ -10,7 +10,9 @@ import scalafx.scene.control.{
   TextField,
   MenuBar,
   Menu,
-  MenuItem
+  MenuItem,
+  Alert,
+  Tooltip
 }
 import scalafx.scene.layout.{BorderPane, GridPane, VBox}
 import scalafx.application.Platform
@@ -21,6 +23,7 @@ import entystal.viewmodel.RegistroViewModel
 import entystal.gui.ThemeManager
 import entystal.i18n.I18n
 import entystal.ledger.Ledger
+import entystal.service.StatusNotifier
 import zio.Runtime
 import java.util.Locale
 
@@ -29,12 +32,12 @@ import java.util.Locale
 class MainView(
     vm: RegistroViewModel,
     ledger: Ledger,
-    statusLabel: Label,
-    notifier: StatusNotifier
+    statusLabel: Label = new Label("")
 )(implicit runtime: Runtime[Any]) {
   private val labelTipo        = new Label()
   private val labelId          = new Label()
   private val labelDescripcion = new Label()
+  private val notifier         = new StatusNotifier(statusLabel)
   private val langChoice       = new ChoiceBox[String](ObservableBuffer("es", "en")) {
     value = I18n.locale.value.getLanguage
   }
@@ -45,7 +48,7 @@ class MainView(
   private val idField          = new TextField() { text <==> vm.identificador }
   private val descField        = new TextField() { text <==> vm.descripcion }
   private val registrarTooltip = new Tooltip()
-  private val registrarBtn     = new Button() {
+  val registrarBtn             = new Button() {
     disable <== vm.puedeRegistrar.not()
     mnemonicParsing = true
     onAction = _ => vm.registrar()
@@ -146,6 +149,14 @@ class MainView(
   val scene = new Scene(600, 400) {
     root = rootPane
     stylesheets += ThemeManager.loadTheme().css
+  }
+
+  private def toggleTheme(): Unit = {
+    val nuevo = ThemeManager.loadTheme() match {
+      case ThemeManager.Dark  => ThemeManager.Light
+      case ThemeManager.Light => ThemeManager.Dark
+    }
+    ThemeManager.applyTheme(scene, nuevo)
   }
 
   private def mostrarAcerca(): Unit = {

--- a/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
+++ b/core/src/test/scala/entystal/service/RegistroServiceSpec.scala
@@ -67,7 +67,8 @@ class RegistroServiceSpec extends AnyFlatSpec with Matchers {
         .getOrThrow()
     }
     val service = new RegistroService(ledger)
-    val tmpCsv  = java.nio.file.Files.createTempFile("reg", ".csv")
+    val tmpCsv  =
+      java.nio.file.Files.createTempFile(entystal.util.CsvExporter.baseDir, "reg", ".csv")
     zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(service.registrar(RegistroData("activo", "a1", "d"))).getOrThrow()
     }
@@ -84,7 +85,8 @@ class RegistroServiceSpec extends AnyFlatSpec with Matchers {
         .getOrThrow()
     }
     val service = new RegistroService(ledger)
-    val tmpPdf  = java.nio.file.Files.createTempFile("reg", ".pdf")
+    val tmpPdf  =
+      java.nio.file.Files.createTempFile(entystal.util.PdfExporter.baseDir, "reg", ".pdf")
     zio.Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(service.registrar(RegistroData("pasivo", "p1", ""))).getOrThrow()
     }

--- a/core/src/test/scala/entystal/util/CsvExporterSpec.scala
+++ b/core/src/test/scala/entystal/util/CsvExporterSpec.scala
@@ -9,7 +9,7 @@ import zio.Runtime
 class CsvExporterSpec extends AnyFlatSpec with Matchers {
   "CsvExporter" should "generar un fichero con cabecera" in {
     val entries = List(AssetEntry(DataAsset("a1", "info", 1L, BigDecimal(1))))
-    val tmp     = java.nio.file.Files.createTempFile("hist", ".csv")
+    val tmp     = java.nio.file.Files.createTempFile(CsvExporter.baseDir, "hist", ".csv")
     val rt      = Runtime.default
     zio.Unsafe.unsafe { implicit u =>
       rt.unsafe

--- a/core/src/test/scala/entystal/util/PdfExporterSpec.scala
+++ b/core/src/test/scala/entystal/util/PdfExporterSpec.scala
@@ -10,7 +10,7 @@ import zio.Runtime
 class PdfExporterSpec extends AnyFlatSpec with Matchers {
   "PdfExporter" should "crear un PDF no vacío" in {
     val entries = List(LiabilityEntry(BasicLiability("l1", BigDecimal(1), 2L)))
-    val tmp     = java.nio.file.Files.createTempFile("hist", ".pdf")
+    val tmp     = java.nio.file.Files.createTempFile(PdfExporter.baseDir, "hist", ".pdf")
     val rt      = Runtime.default
     zio.Unsafe.unsafe { implicit u =>
       rt.unsafe

--- a/core/src/test/scala/entystal/view/AccessibilitySpec.scala
+++ b/core/src/test/scala/entystal/view/AccessibilitySpec.scala
@@ -17,11 +17,11 @@ class AccessibilitySpec extends AnyFlatSpec with Matchers {
     val ledger: Ledger            = zio.Unsafe.unsafe { implicit u =>
       rt.unsafe.run(zio.ZIO.scoped(InMemoryLedger.live.build.map(_.get))).getOrThrow()
     }
-    val service  = new RegistroService(ledger)
-    val notifier = new TestNotifier
-    val vm       = new RegistroViewModel(service, notifier)
+    val service                   = new RegistroService(ledger)
+    val notifier                  = new TestNotifier
+    val vm                        = new RegistroViewModel(service, notifier)
 
-    val mainView     = new MainView(vm, ledger)
+    val mainView = new MainView(vm, ledger)
     mainView.registrarBtn.accessibleText.value shouldBe "Registrar"
     mainView.registrarBtn.mnemonicParsing.value shouldBe true
 
@@ -29,8 +29,8 @@ class AccessibilitySpec extends AnyFlatSpec with Matchers {
     busquedaView.buscarBtn.accessibleText.value shouldBe "Buscar"
     busquedaView.buscarBtn.mnemonicParsing.value shouldBe true
 
-    val entry        = AssetEntry(DataAsset("a1", "d", 1L, BigDecimal(1)))
-    val edicionView  = new EdicionView(entry)
+    val entry       = AssetEntry(DataAsset("a1", "d", 1L, BigDecimal(1)))
+    val edicionView = new EdicionView(entry)
     edicionView.guardarBtn.accessibleText.value shouldBe "Guardar cambios"
     edicionView.guardarBtn.mnemonicParsing.value shouldBe true
   }


### PR DESCRIPTION
## Resumen
- se añade control de directorio en `CsvExporter` y `PdfExporter`
- se actualizan pruebas para usar el directorio permitido
- se incorporan mejoras en las vistas para compilar con los tests

## Checklist
- [x] `sbt scalafmtAll`
- [x] `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_68698f1a16f4832bba0711289b86c696