### PR TITLE
Implementación de JWT y HTTPS en RestServer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,8 @@ lazy val rest = (project in file("rest"))
       "io.prometheus" % "simpleclient" % "0.16.0",
       "io.prometheus" % "simpleclient_common" % "0.16.0",
       "org.scalatest" %% "scalatest" % "3.2.18" % Test,
-      "dev.zio" %% "zio-json" % "0.6.2"
+      "dev.zio" %% "zio-json" % "0.6.2",
+      "com.auth0" % "java-jwt" % "4.5.0",
+      "org.http4s" %% "http4s-blaze-server" % "0.23.17"
     )
   )

--- a/rest/src/main/scala/entystal/auth/AuthService.scala
+++ b/rest/src/main/scala/entystal/auth/AuthService.scala
@@ -1,0 +1,27 @@
+package entystal.auth
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import java.util.Date
+
+object AuthService {
+  private val secret = sys.env.getOrElse("JWT_SECRET", "entystal-secret")
+
+  private val algo = Algorithm.HMAC256(secret)
+
+  def generateToken(user: String): String =
+    JWT
+      .create()
+      .withSubject(user)
+      .withIssuedAt(new Date())
+      .withExpiresAt(new Date(System.currentTimeMillis() + 3600 * 1000))
+      .sign(algo)
+
+  def validateToken(token: String): Boolean =
+    try {
+      JWT.require(algo).build().verify(token)
+      true
+    } catch {
+      case _: Throwable => false
+    }
+}

--- a/rest/src/main/scala/entystal/auth/JwtMiddleware.scala
+++ b/rest/src/main/scala/entystal/auth/JwtMiddleware.scala
@@ -1,0 +1,24 @@
+package entystal.auth
+
+import cats.data.{Kleisli, OptionT}
+import cats.effect.IO
+import org.http4s.{HttpRoutes, Request}
+import org.http4s.dsl.io._
+import org.http4s.headers.Authorization
+import org.http4s.{AuthScheme, Credentials}
+
+object JwtMiddleware {
+  private val Bearer = "Bearer "
+
+  def apply(routes: HttpRoutes[IO]): HttpRoutes[IO] = Kleisli { (req: Request[IO]) =>
+    val valid = req.headers
+      .get[Authorization]
+      .collect { case Authorization(Credentials.Token(AuthScheme.Bearer, token)) =>
+        AuthService.validateToken(token)
+      }
+      .getOrElse(false)
+
+    if (valid) routes(req)
+    else OptionT.liftF(Forbidden("Token inválido"))
+  }
+}

--- a/rest/src/main/scala/entystal/rest/RestServer.scala
+++ b/rest/src/main/scala/entystal/rest/RestServer.scala
@@ -3,10 +3,14 @@ package entystal.rest
 import cats.effect.{IO, IOApp}
 import cats.syntax.semigroupk._
 import org.http4s.server.Router
-import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.blaze.server.BlazeServerBuilder
 import com.comcast.ip4s._
 import entystal.service.RegistroService
 import entystal.EntystalModule
+import entystal.auth.JwtMiddleware
+import java.io.FileInputStream
+import java.security.{KeyStore, SecureRandom}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 import zio.{Runtime, Unsafe}
 
 /** Servidor HTTP básico para registrar eventos y consultar historial */
@@ -17,14 +21,32 @@ object RestServer extends IOApp.Simple {
       runtime.unsafe.run(zio.ZIO.scoped(EntystalModule.layer.build.map(_.get))).getOrThrow()
     }
     val service                        = new RegistroService(ledger)
-    val api                            = new RestRoutes(service).routes <+> Metrics.routes
+    val api                            = JwtMiddleware(new RestRoutes(service).routes <+> Metrics.routes)
 
-    EmberServerBuilder
-      .default[IO]
-      .withHost(host"0.0.0.0")
-      .withPort(port"8080")
+    val sslContext = for {
+      path <- sys.env.get("HTTPS_KEYSTORE_PATH")
+      pass <- sys.env.get("HTTPS_KEYSTORE_PASSWORD")
+    } yield {
+      val ks  = KeyStore.getInstance("PKCS12")
+      val fis = new FileInputStream(path)
+      ks.load(fis, pass.toCharArray)
+      fis.close()
+      val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+      kmf.init(ks, pass.toCharArray)
+      val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      tmf.init(ks)
+      val ctx = SSLContext.getInstance("TLS")
+      ctx.init(kmf.getKeyManagers, tmf.getTrustManagers, new SecureRandom())
+      ctx
+    }
+
+    val builder = BlazeServerBuilder[IO]
+      .bindHttp(8080, "0.0.0.0")
       .withHttpApp(Router("/" -> api).orNotFound)
-      .build
+
+    sslContext
+      .fold(builder)(ctx => builder.withSslContext(ctx))
+      .resource
       .useForever
   }
 }


### PR DESCRIPTION
## Resumen
- se añade `AuthService` basado en java-jwt
- se crea `JwtMiddleware` para proteger rutas
- `RestServer` usa BlazeServerBuilder con TLS opcional
- se declara nueva dependencia en `build.sbt`

## Testing
- `sbt scalafmtAll` ✔️
- `sbt test` falló por dependencias no disponibles en el entorno


------
https://chatgpt.com/codex/tasks/task_e_68698f1a9c7c832ba2ec0b49c80c7259