### PR TITLE
Añadir gateway Akka HTTP con SAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,22 @@ El código principal se encuentra en la carpeta `core/` y está organizado en m�
 - Interfaz gráfica (GUI) básica con ScalaFX para registrar activos, pasivos e inversiones.
 - Generación de JAR ejecutable mediante `sbt-assembly`.
 - Nuevo módulo `rest` con API HTTP para registrar eventos y consultar historial.
+- Nuevo módulo `gateway` con Akka HTTP que aplica rate limiting y SSO/SAML, y enruta al `RestServer`.
 
 ## Accesibilidad
 
 La GUI ahora define texto accesible (`accessibleText`) en cada botón y campo,
 atajos de teclado mediante `mnemonicParsing` para las acciones principales y un
 orden de tabulación lógico para navegar sólo con el teclado.
+
+## Arquitectura
+
+```
+[Usuarios] -> gateway (Akka HTTP + SAML) -> RestServer (http4s) -> core
+```
+
+El `gateway` autentica via SAML, limita la tasa por IP y delega las peticiones
+al `RestServer`, que a su vez expone la lógica definida en `core`.
 
 ## Requisitos
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
 lazy val root = (project in file("."))
-  .aggregate(core, rest)
+  .aggregate(core, rest, gateway)
   .settings(
     name := "entystal-root"
   )
@@ -84,4 +84,17 @@ lazy val rest = (project in file("rest"))
       "com.auth0" % "java-jwt" % "4.5.0",
       "org.http4s" %% "http4s-blaze-server" % "0.23.17"
     )
+  )
+
+lazy val gateway = (project in file("gateway"))
+  .dependsOn(rest)
+  .settings(
+    name := "entystal-gateway",
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-http" % "10.6.0",
+      "com.typesafe.akka" %% "akka-stream" % "2.8.5",
+      "com.stackstate" %% "akka-http-pac4j" % "1.0.1",
+      "org.pac4j" % "pac4j-saml-opensamlv5" % "5.7.7"
+    ),
+    resolvers += "Shibboleth Releases" at "https://maven.shibboleth.net/releases"
   )

--- a/gateway/src/main/scala/entystal/gateway/GatewayServer.scala
+++ b/gateway/src/main/scala/entystal/gateway/GatewayServer.scala
@@ -1,0 +1,63 @@
+package entystal.gateway
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.Host
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.stackstate.akka.http.pac4j.{CallbackDirective, SecurityDirectives}
+import org.pac4j.core.client.Clients
+import org.pac4j.core.config.Config
+import org.pac4j.saml.client.SAML2Client
+import org.pac4j.saml.config.SAML2Configuration
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+/** Servidor de puerta de entrada con Akka HTTP */
+object GatewayServer extends App {
+  implicit val system = ActorSystem("gateway-system")
+  implicit val ec     = system.dispatcher
+
+  private val samlConfig = new SAML2Configuration(
+    sys.env.getOrElse("SAML_IDP_METADATA", "idp-metadata.xml"),
+    sys.env.getOrElse("SAML_SP_KEYSTORE", "keystore.jks"),
+    sys.env.getOrElse("SAML_KEYSTORE_PASSWORD", "changeit"),
+    sys.env.getOrElse("SAML_PRIVATEKEY_PASSWORD", "changeit")
+  )
+  private val samlClient = new SAML2Client(samlConfig)
+  private val clients    = new Clients("http://localhost:9000/callback", samlClient)
+  private val config     = new Config(clients)
+  private val security   = new SecurityDirectives(config)
+  private val callback   = new CallbackDirective(config)
+
+  private def forward(req: HttpRequest): Future[HttpResponse] = {
+    val proxied = req
+      .withUri("http://localhost:8080" + req.uri.path.toString())
+      .withHeaders(req.headers.filterNot(_.is("host")))
+    Http().singleRequest(proxied)
+  }
+
+  private val proxyRoutes: Route = extractClientIP { ip =>
+    if (!RateLimiter.allow(ip.toOption.map(_.getHostAddress).getOrElse("unknown")))
+      complete(StatusCodes.TooManyRequests, "Límite superado")
+    else extractRequest { r => complete(forward(r)) }
+  }
+
+  private val routes: Route =
+    path("callback") {
+      callback()
+    } ~
+      security.authenticated("SAML2Client") {
+        proxyRoutes
+      }
+
+  Http().newServerAt("0.0.0.0", 9000).bind(routes).onComplete {
+    case Success(binding) =>
+      system.log.info(s"Gateway escuchando en ${binding.localAddress}")
+    case Failure(err)     =>
+      system.log.error("No se pudo iniciar el gateway", err)
+      system.terminate()
+  }
+}

--- a/gateway/src/main/scala/entystal/gateway/RateLimiter.scala
+++ b/gateway/src/main/scala/entystal/gateway/RateLimiter.scala
@@ -1,0 +1,22 @@
+package entystal.gateway
+
+import scala.collection.concurrent.TrieMap
+
+/** Control de tasa simple tipo token bucket por IP */
+object RateLimiter {
+  private case class Bucket(tokens: Int, last: Long)
+  private val capacity = 20
+  private val refillMs = 60000L
+  private val buckets  = TrieMap.empty[String, Bucket]
+
+  def allow(ip: String): Boolean = synchronized {
+    val now    = System.currentTimeMillis()
+    val bucket = buckets.getOrElse(ip, Bucket(capacity, now))
+    val fresh  =
+      if (now - bucket.last >= refillMs) Bucket(capacity - 1, now)
+      else if (bucket.tokens > 0) bucket.copy(tokens = bucket.tokens - 1)
+      else bucket
+    buckets.update(ip, fresh)
+    fresh.tokens >= 0
+  }
+}


### PR DESCRIPTION
## Summary
- crear módulo `gateway` con Akka HTTP
- aplicar rate limiting por IP y autenticación SAML con pac4j
- enrutar llamadas al `RestServer`
- documentar la nueva arquitectura en el README

## Testing
- `sbt scalafmtAll` *(failed: plugin no ejecutó tareas)*
- `sbt compile` *(falló por dependencias de OpenSAML)*
- `sbt test` *(falló por dependencias de OpenSAML)*


------
https://chatgpt.com/codex/tasks/task_e_686997ecd874832bb76e0433906e67c2